### PR TITLE
Support recent kernel versions

### DIFF
--- a/device.c
+++ b/device.c
@@ -1,5 +1,6 @@
 #define pr_fmt(fmt) KBUILD_MODNAME ": " fmt
 
+#include <linux/version.h>
 #include <linux/spinlock.h>
 #include <linux/time.h>
 #include <media/videobuf2-core.h>
@@ -771,7 +772,12 @@ struct vcam_device *create_vcam_device(size_t idx,
     snprintf(vdev->name, sizeof(vdev->name), "%s-%d", vcam_dev_name, (int) idx);
     video_set_drvdata(vdev, vcam);
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,7,0)
+    ret = video_register_device(vdev, VFL_TYPE_VIDEO, -1);
+#else
     ret = video_register_device(vdev, VFL_TYPE_GRABBER, -1);
+#endif
+
     if (ret < 0) {
         pr_err("video_register_device failure\n");
         goto video_regdev_failure;

--- a/fb.c
+++ b/fb.c
@@ -1,5 +1,6 @@
 #define pr_fmt(fmt) KBUILD_MODNAME ": " fmt
 
+#include <linux/version.h>
 #include <linux/proc_fs.h>
 #include <linux/spinlock.h>
 
@@ -104,12 +105,20 @@ static ssize_t vcamfb_write(struct file *file,
     return to_be_copyied;
 }
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,6,0)
+static struct proc_ops vcamfb_fops = {
+     .proc_open = vcamfb_open,
+     .proc_release = vcamfb_release,
+     .proc_write = vcamfb_write,
+};
+#else
 static struct file_operations vcamfb_fops = {
     .owner = THIS_MODULE,
     .open = vcamfb_open,
     .release = vcamfb_release,
     .write = vcamfb_write,
 };
+#endif
 
 struct proc_dir_entry *init_framebuffer(const char *proc_fname,
                                         struct vcam_device *dev)


### PR DESCRIPTION
Problem: Some error infos are from the gcc
Cause: The kernel is from 4.15 to 5.8, Some API was changed or missed.
Solution: Check the git from kernel, and refer vivid which is device driver in kernel.