### PR TITLE
revert some changes of ec33081 (v4l2_find_nearest_size)

### DIFF
--- a/device.c
+++ b/device.c
@@ -151,6 +151,7 @@ static int vcam_try_fmt_vid_cap(struct file *file,
         f->fmt.pix.height = dev->output_format.height;
     }
 
+/*
     if (dev->conv_res_on) {
         int n_avail = ARRAY_SIZE(vcam_sizes);
         const struct v4l2_frmsize_discrete *sz = v4l2_find_nearest_size(
@@ -160,6 +161,7 @@ static int vcam_try_fmt_vid_cap(struct file *file,
         f->fmt.pix.height = sz->height;
         vcam_update_format_cap(dev, false);
     }
+*/
 
     f->fmt.pix.field = V4L2_FIELD_NONE;
     if (f->fmt.pix.pixelformat == V4L2_PIX_FMT_YUYV) {


### PR DESCRIPTION
It could resolve some errors like this:

```
make -C /lib/modules/4.15.0-147-generic/build M=/home/myworld/Github/vcam modules
make[1]: Entering directory '/usr/src/linux-headers-4.15.0-147-generic'
  CC [M]  /home/myworld/Github/vcam/device.o
/home/myworld/Github/vcam/device.c: In function ‘vcam_try_fmt_vid_cap’:
/home/myworld/Github/vcam/device.c:156:50: error: implicit declaration of function ‘v4l2_find_nearest_size’; did you mean ‘v4l2_find_nearest_format’? [-Werror=implicit-function-declaration]
         const struct v4l2_frmsize_discrete *sz = v4l2_find_nearest_size(
                                                  ^~~~~~~~~~~~~~~~~~~~~~
                                                  v4l2_find_nearest_format
/home/myworld/Github/vcam/device.c:157:34: error: ‘width’ undeclared (first use in this function)
             vcam_sizes, n_avail, width, height, vcam_sizes[n_avail - 1].width,
                                  ^~~~~
/home/myworld/Github/vcam/device.c:157:34: note: each undeclared identifier is reported only once for each function it appears in
/home/myworld/Github/vcam/device.c:157:41: error: ‘height’ undeclared (first use in this function); did you mean ‘hweight8’?
             vcam_sizes, n_avail, width, height, vcam_sizes[n_avail - 1].width,
                                         ^~~~~~
                                         hweight8
cc1: some warnings being treated as errors
scripts/Makefile.build:333: recipe for target '/home/myworld/Github/vcam/device.o' failed
make[2]: *** [/home/myworld/Github/vcam/device.o] Error 1
Makefile:1591: recipe for target '_module_/home/myworld/Github/vcam' failed
make[1]: *** [_module_/home/myworld/Github/vcam] Error 2
make[1]: Leaving directory '/usr/src/linux-headers-4.15.0-147-generic'
Makefile:14: recipe for target 'kmod' failed
make: *** [kmod] Error 2
```