### PR TITLE
Fix v4l2_find_nearest_size in Linux kernel v4.15 

### DIFF
--- a/device.c
+++ b/device.c
@@ -153,9 +153,18 @@ static int vcam_try_fmt_vid_cap(struct file *file,
 
     if (dev->conv_res_on) {
         int n_avail = ARRAY_SIZE(vcam_sizes);
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 17, 0)
         const struct v4l2_frmsize_discrete *sz = v4l2_find_nearest_size(
             vcam_sizes, n_avail, width, height, vcam_sizes[n_avail - 1].width,
             vcam_sizes[n_avail - 1].height);
+#else
+        const struct v4l2_discrete_probe vcam_probe = {
+            vcam_sizes, ARRAY_SIZE(vcam_sizes)};
+
+        const struct v4l2_frmsize_discrete *sz =
+            v4l2_find_nearest_format(&vcam_probe, vcam_sizes[n_avail - 1].width,
+                                     vcam_sizes[n_avail - 1].height);
+#endif
         f->fmt.pix.width = sz->width;
         f->fmt.pix.height = sz->height;
         vcam_update_format_cap(dev, false);


### PR DESCRIPTION
follow up the [pull request #7](https://github.com/jserv/vcam/pull/7)
the Linux kernel v4.15 didn't define v4l2_find_nearest_size().
use the v4l2_find_nearest_format() to replace it.
```
Driver Info (not using libv4l2):
	Driver name   : vcam
	Card type     : vcam
	Bus info      : platform: virtual
	Driver version: 4.15.18
	Capabilities  : 0x85200001
		Video Capture
		Read/Write
		Streaming
		Extended Pix Format
		Device Capabilities
	Device Caps   : 0x05200001
		Video Capture
		Read/Write
		Streaming
		Extended Pix Format
Priority: 2
Video input : 0 (vcam_in 0: ok)
Format Video Capture:
	Width/Height      : 1280/720
	Pixel Format      : 'RGB3'
	Field             : None
	Bytes per Line    : 3840
	Size Image        : 2764800
	Colorspace        : sRGB
	Transfer Function : Default (maps to sRGB)
	YCbCr/HSV Encoding: Default (maps to ITU-R 601)
	Quantization      : Default (maps to Full Range)
	Flags             : 
Streaming Parameters Video Capture:
	Frames per second: 29.970 (30000/1001)
	Read buffers     : 1
```