### PR TITLE
Enables image cropping

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,10 +39,10 @@ Expectedly, two device nodes will be created in `/dev`:
 * videoX - V4L2 device;
 * vcamctl - Control device for virtual camera(s), used by control utility `vcam-util`;
 
-In `/proc` directory, device file `fbX` will be created.
+In `/proc` directory, device file `vcamfbX` will be created.
 
 The device if initialy configured to process 640x480 RGB24 image format.
-By writing 640x480 RGB24 raw frame data to `/proc/fbX` file the resulting
+By writing 640x480 RGB24 raw frame data to `/proc/vcamfbX` file the resulting
 video stream will appear on corresponding `/dev/videoX` V4L2 device(s).
 
 Run `vcam-util --help` for more information about how to configure, add or
@@ -84,6 +84,13 @@ Driver Info:
 		Extended Pix Format
 		Device Capabilities
 ```
+
+Available parameters in the `module.c`:
+* `devices_max` - Maximal number of devices. The default is 8.
+* `create_devices` - Number of devices to be created during initialization. The default is 1.
+* `allow_pix_conversion` - Allow pixel format conversion from RGB24 to YUYV. The default is OFF.
+* `allow_scaling` - Allow image scaling from 480p to 720p. The default is OFF.
+* `allow_cropping` - Allow image cropping in Four-Thirds system. The default is OFF.
 
 ## Related Projects
 

--- a/device.c
+++ b/device.c
@@ -175,6 +175,8 @@ static int vcam_try_fmt_vid_cap(struct file *file,
         f->fmt.pix.height = sz->height;
         dev->output_format.width = sz->width;
         dev->output_format.height = sz->height;
+
+        /* set the output_format on YUYV or SRGB*/
         if (dev->output_format.pixelformat == V4L2_PIX_FMT_YUYV) {
             dev->output_format.bytesperline = dev->output_format.width << 1;
             dev->output_format.colorspace = V4L2_COLORSPACE_SMPTE170M;
@@ -188,6 +190,7 @@ static int vcam_try_fmt_vid_cap(struct file *file,
     }
 
     if (dev->conv_crop_on) {
+        /* set the rectangular size for the cropping */
         struct v4l2_rect *crop = &dev->crop_cap;
         struct v4l2_rect r = {0, 0, f->fmt.pix.width, f->fmt.pix.height};
         struct v4l2_rect min_r = {0, 0, r.width * 3 / 4, r.height * 3 / 4};
@@ -198,6 +201,8 @@ static int vcam_try_fmt_vid_cap(struct file *file,
         dev->crop_output_format.width = crop->width;
         dev->crop_output_format.height = crop->height;
         pr_debug("Output crop is %d", dev->conv_crop_on);
+
+        /* set the cropping v4l2_format on YUYV or SRGB */
         f->fmt.pix.width = dev->crop_output_format.width;
         f->fmt.pix.height = dev->crop_output_format.height;
         f->fmt.pix.field = V4L2_FIELD_NONE;
@@ -920,7 +925,6 @@ input_buffer_failure:
 framebuffer_failure:
     destroy_framebuffer(vcam->vcam_fb_fname);
 video_regdev_failure:
-    /* TODO: vb2 deinit */
     video_unregister_device(&vcam->vdev);
     video_device_release(&vcam->vdev);
 vb2_out_init_failed:

--- a/device.c
+++ b/device.c
@@ -4,6 +4,7 @@
 #include <linux/time.h>
 #include <linux/version.h>
 #include <media/v4l2-image-sizes.h>
+#include <media/v4l2-rect.h>
 #include <media/videobuf2-core.h>
 #include <media/videobuf2-vmalloc.h>
 
@@ -14,6 +15,7 @@
 extern const char *vcam_dev_name;
 extern unsigned char allow_pix_conversion;
 extern unsigned char allow_scaling;
+extern unsigned char allow_cropping;
 
 struct __attribute__((__packed__)) rgb_struct {
     unsigned char r, g, b;
@@ -118,8 +120,13 @@ static int vcam_g_fmt_vid_cap(struct file *file,
                               struct v4l2_format *f)
 {
     struct vcam_device *dev = (struct vcam_device *) video_drvdata(file);
-    memcpy(&f->fmt.pix, &dev->output_format, sizeof(struct v4l2_pix_format));
-
+    if (dev->conv_crop_on) {
+        memcpy(&f->fmt.pix, &dev->crop_output_format,
+               sizeof(struct v4l2_pix_format));
+    } else {
+        memcpy(&f->fmt.pix, &dev->output_format,
+               sizeof(struct v4l2_pix_format));
+    }
     return 0;
 }
 
@@ -158,8 +165,7 @@ static int vcam_try_fmt_vid_cap(struct file *file,
             vcam_sizes, n_avail, width, height, vcam_sizes[n_avail - 1].width,
             vcam_sizes[n_avail - 1].height);
 #else
-        const struct v4l2_discrete_probe vcam_probe = {
-            vcam_sizes, ARRAY_SIZE(vcam_sizes)};
+        const struct v4l2_discrete_probe vcam_probe = {vcam_sizes, n_avail};
 
         const struct v4l2_frmsize_discrete *sz =
             v4l2_find_nearest_format(&vcam_probe, vcam_sizes[n_avail - 1].width,
@@ -167,7 +173,44 @@ static int vcam_try_fmt_vid_cap(struct file *file,
 #endif
         f->fmt.pix.width = sz->width;
         f->fmt.pix.height = sz->height;
+        dev->output_format.width = sz->width;
+        dev->output_format.height = sz->height;
+        if (dev->output_format.pixelformat == V4L2_PIX_FMT_YUYV) {
+            dev->output_format.bytesperline = dev->output_format.width << 1;
+            dev->output_format.colorspace = V4L2_COLORSPACE_SMPTE170M;
+        } else {
+            dev->output_format.bytesperline = dev->output_format.width * 3;
+            dev->output_format.colorspace = V4L2_COLORSPACE_SRGB;
+        }
+        dev->output_format.sizeimage =
+            dev->output_format.bytesperline * dev->output_format.height;
         vcam_update_format_cap(dev, false);
+    }
+
+    if (dev->conv_crop_on) {
+        struct v4l2_rect *crop = &dev->crop_cap;
+        struct v4l2_rect r = {0, 0, f->fmt.pix.width, f->fmt.pix.height};
+        struct v4l2_rect min_r = {0, 0, r.width * 3 / 4, r.height * 3 / 4};
+        struct v4l2_rect max_r = {0, 0, r.width, r.height};
+        v4l2_rect_set_min_size(crop, &min_r);
+        v4l2_rect_set_max_size(crop, &max_r);
+        dev->crop_output_format = dev->output_format;
+        dev->crop_output_format.width = crop->width;
+        dev->crop_output_format.height = crop->height;
+        pr_debug("Output crop is %d", dev->conv_crop_on);
+        f->fmt.pix.width = dev->crop_output_format.width;
+        f->fmt.pix.height = dev->crop_output_format.height;
+        f->fmt.pix.field = V4L2_FIELD_NONE;
+        if (f->fmt.pix.pixelformat == V4L2_PIX_FMT_YUYV) {
+            f->fmt.pix.bytesperline = dev->output_format.width << 1;
+            f->fmt.pix.colorspace = V4L2_COLORSPACE_SMPTE170M;
+        } else {
+            f->fmt.pix.bytesperline = dev->output_format.width * 3;
+            f->fmt.pix.colorspace = V4L2_COLORSPACE_SRGB;
+        }
+        f->fmt.pix.sizeimage =
+            f->fmt.pix.bytesperline * dev->output_format.height;
+        return 0;
     }
 
     f->fmt.pix.field = V4L2_FIELD_NONE;
@@ -199,7 +242,12 @@ static int vcam_s_fmt_vid_cap(struct file *file,
     if (ret < 0)
         return ret;
 
-    dev->output_format = f->fmt.pix;
+    if (dev->conv_crop_on) {
+        dev->crop_output_format = f->fmt.pix;
+    } else {
+        dev->output_format = f->fmt.pix;
+    }
+
     pr_debug("Resolution set to %dx%d\n", dev->output_format.width,
              dev->output_format.height);
     return 0;
@@ -836,6 +884,7 @@ struct vcam_device *create_vcam_device(size_t idx,
     /* Setup conversion capabilities */
     vcam->conv_res_on = (bool) allow_scaling;
     vcam->conv_pixfmt_on = (bool) allow_pix_conversion;
+    vcam->conv_crop_on = (bool) allow_cropping;
 
     /* Alloc and set initial format */
     if (vcam->conv_pixfmt_on) {
@@ -872,6 +921,8 @@ framebuffer_failure:
     destroy_framebuffer(vcam->vcam_fb_fname);
 video_regdev_failure:
     /* TODO: vb2 deinit */
+    video_unregister_device(&vcam->vdev);
+    video_device_release(&vcam->vdev);
 vb2_out_init_failed:
     v4l2_device_unregister(&vcam->v4l2_dev);
 v4l2_registration_failure:

--- a/device.h
+++ b/device.h
@@ -82,9 +82,13 @@ struct vcam_device {
     struct v4l2_pix_format output_format;
     struct v4l2_pix_format input_format;
 
+    struct v4l2_pix_format crop_output_format;
+    struct v4l2_rect crop_cap;
+
     /* Conversion switches */
     bool conv_pixfmt_on;
     bool conv_res_on;
+    bool conv_crop_on;
 };
 
 struct vcam_device *create_vcam_device(size_t idx,

--- a/module.c
+++ b/module.c
@@ -15,6 +15,7 @@ unsigned short devices_max = 8;
 unsigned short create_devices = 1;
 unsigned char allow_pix_conversion = 0;
 unsigned char allow_scaling = 0;
+unsigned char allow_cropping = 0;
 
 module_param(devices_max, ushort, 0);
 MODULE_PARM_DESC(devices_max, "Maximal number of devices\n");
@@ -29,6 +30,9 @@ MODULE_PARM_DESC(allow_pix_conversion,
 
 module_param(allow_scaling, byte, 0);
 MODULE_PARM_DESC(allow_scaling, "Allow image scaling by default\n");
+
+module_param(allow_cropping, byte, 0);
+MODULE_PARM_DESC(allow_cropping, "Allow image cropping by default\n");
 
 const char *vcam_dev_name = VCAM_DEV_NAME;
 


### PR DESCRIPTION
The camera device support cropping on recent devices,
because it can emphasize which part is more important.
This patch adopts predefined the v4l2_rect_set_min_size() and
v4l2_rect_set_max_size() to set the rectangular size.
The default is the Four-Thirds system which is usually in cropping.

To check the functionality, use the following command:
$ sudo v4l2-ctl -d /dev/video2 --all
```
Video input : 0 (vcam_in 0: ok)
Format Video Capture:
	Width/Height      : 480/360
	Pixel Format      : 'RGB3' (24-bit RGB 8-8-8)
	Field             : None
	Bytes per Line    : 1920
	Size Image        : 921600
```