### PR TITLE
Make controlling framebuffer configurable and flexible

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,14 +35,15 @@ The module can be loaded to Linux kernel by runnning the command:
 $ sudo insmod vcam.ko
 ```
 
-Expectedly, two device nodes will be created in `/dev`:
+Expectedly, three device nodes will be created in `/dev`:
 * videoX - V4L2 device;
 * vcamctl - Control device for virtual camera(s), used by control utility `vcam-util`;
+* fbX - controlling framebuffer device;
 
-In `/proc` directory, device file `vcamfbX` will be created.
+In `/dev` directory, device file `fbX` will be created.
 
 The device if initialy configured to process 640x480 RGB24 image format.
-By writing 640x480 RGB24 raw frame data to `/proc/vcamfbX` file the resulting
+By writing 640x480 RGB24 raw frame data to `/dev/fbX` file the resulting
 video stream will appear on corresponding `/dev/videoX` V4L2 device(s).
 
 Run `vcam-util --help` for more information about how to configure, add or
@@ -55,7 +56,7 @@ $ sudo ./vcam-util -l
 You should get:
 ```
 Available virtual V4L2 compatible devices:
-1. vcamfb0(640,480,rgb24) -> /dev/video0
+1. fbX(640,480,rgb24) -> /dev/video0
 ```
 
 You can use this command to check if the driver is ok:
@@ -83,6 +84,26 @@ Driver Info:
 		Streaming
 		Extended Pix Format
 		Device Capabilities
+```
+You can check framebuffer format with this command:
+```shell
+$ sudo fbset -fb /dev/fbX --info
+```
+
+You will get information as following:
+```shell
+mode "640x480"
+    geometry 640 480 640 480 24
+    timings 0 0 0 0 0 0 0
+    rgba 8/0,8/8,8/16,0/0
+endmode
+
+Frame buffer device information:
+    Name        : vcamfb
+    Address     : 0xffffa293438ed000
+    Size        : 921600
+    Type        : PACKED PIXELS
+    Visual      : TRUECOLOR
 ```
 
 Available parameters for `vcam` kernel module:

--- a/control.c
+++ b/control.c
@@ -65,7 +65,7 @@ static ssize_t control_write(struct file *file,
 static int control_iocontrol_get_device(struct vcam_device_spec *dev_spec)
 {
     struct vcam_device *dev;
-    struct vcamfb_info *fb_data;
+
     if (ctldev->vcam_device_count <= dev_spec->idx)
         return -EINVAL;
 
@@ -76,8 +76,8 @@ static int control_iocontrol_get_device(struct vcam_device_spec *dev_spec)
         dev_spec->pix_fmt = VCAM_PIXFMT_YUYV;
     else
         dev_spec->pix_fmt = VCAM_PIXFMT_RGB24;
-    fb_data = dev->fb_priv;
-    strncpy((char *) &dev_spec->fb_node, (const char *) &fb_data->fb_name,
+
+    strncpy((char *) &dev_spec->fb_node, (const char *) get_vcamfb_name(dev),
             sizeof(dev_spec->fb_node));
     snprintf((char *) &dev_spec->video_node, sizeof(dev_spec->video_node),
              "/dev/video%d", dev->vdev.minor);

--- a/control.c
+++ b/control.c
@@ -9,6 +9,7 @@
 
 #include "control.h"
 #include "device.h"
+#include "fb.h"
 #include "videobuf.h"
 
 extern unsigned short devices_max;
@@ -64,6 +65,7 @@ static ssize_t control_write(struct file *file,
 static int control_iocontrol_get_device(struct vcam_device_spec *dev_spec)
 {
     struct vcam_device *dev;
+    struct vcamfb_info *fb_data;
     if (ctldev->vcam_device_count <= dev_spec->idx)
         return -EINVAL;
 
@@ -74,7 +76,8 @@ static int control_iocontrol_get_device(struct vcam_device_spec *dev_spec)
         dev_spec->pix_fmt = VCAM_PIXFMT_YUYV;
     else
         dev_spec->pix_fmt = VCAM_PIXFMT_RGB24;
-    strncpy((char *) &dev_spec->fb_node, (const char *) &dev->vcam_fb_fname,
+    fb_data = dev->fb_priv;
+    strncpy((char *) &dev_spec->fb_node, (const char *) &fb_data->fb_name,
             sizeof(dev_spec->fb_node));
     snprintf((char *) &dev_spec->video_node, sizeof(dev_spec->video_node),
              "/dev/video%d", dev->vdev.minor);

--- a/control.c
+++ b/control.c
@@ -77,7 +77,7 @@ static int control_iocontrol_get_device(struct vcam_device_spec *dev_spec)
     else
         dev_spec->pix_fmt = VCAM_PIXFMT_RGB24;
 
-    strncpy((char *) &dev_spec->fb_node, (const char *) get_vcamfb_name(dev),
+    strncpy((char *) &dev_spec->fb_node, (const char *) vcamfb_get_devname(dev),
             sizeof(dev_spec->fb_node));
     snprintf((char *) &dev_spec->video_node, sizeof(dev_spec->video_node),
              "/dev/video%d", dev->vdev.minor);

--- a/device.c
+++ b/device.c
@@ -920,7 +920,6 @@ struct vcam_device *create_vcam_device(size_t idx,
 
 vcamfb_failure:
     vcamfb_destroy(vcam);
-    vfree(vcam->fb_priv);
 video_regdev_failure:
     video_unregister_device(&vcam->vdev);
     video_device_release(&vcam->vdev);
@@ -940,7 +939,6 @@ void destroy_vcam_device(struct vcam_device *vcam)
     if (vcam->sub_thr_id)
         kthread_stop(vcam->sub_thr_id);
     vcamfb_destroy(vcam);
-    vfree(vcam->fb_priv);
     mutex_destroy(&vcam->vcam_mutex);
     video_unregister_device(&vcam->vdev);
     v4l2_device_unregister(&vcam->v4l2_dev);

--- a/device.c
+++ b/device.c
@@ -188,7 +188,7 @@ static int vcam_try_fmt_vid_cap(struct file *file,
             dev->output_format.bytesperline * dev->output_format.height;
 
         /* resize the framebuffer */
-        vcam_update_vcamfb(dev);
+        update_vcamfb_format(dev);
     }
 
     if (dev->conv_crop_on) {
@@ -219,7 +219,7 @@ static int vcam_try_fmt_vid_cap(struct file *file,
             f->fmt.pix.bytesperline * dev->output_format.height;
 
         /* resize the framebuffer */
-        vcam_update_vcamfb(dev);
+        update_vcamfb_format(dev);
 
         return 0;
     }

--- a/device.c
+++ b/device.c
@@ -188,7 +188,7 @@ static int vcam_try_fmt_vid_cap(struct file *file,
             dev->output_format.bytesperline * dev->output_format.height;
 
         /* resize the framebuffer */
-        update_vcamfb_format(dev);
+        vcamfb_update(dev);
     }
 
     if (dev->conv_crop_on) {
@@ -219,7 +219,7 @@ static int vcam_try_fmt_vid_cap(struct file *file,
             f->fmt.pix.bytesperline * dev->output_format.height;
 
         /* resize the framebuffer */
-        update_vcamfb_format(dev);
+        vcamfb_update(dev);
 
         return 0;
     }
@@ -906,7 +906,7 @@ struct vcam_device *create_vcam_device(size_t idx,
     vcam->sub_thr_id = NULL;
 
     /* Initialize framebuffer */
-    ret = init_vcamfb(vcam);
+    ret = vcamfb_init(vcam);
     if (ret < 0) {
         pr_err("Failed to initialize vcamfb\n");
         goto vcamfb_failure;
@@ -919,7 +919,7 @@ struct vcam_device *create_vcam_device(size_t idx,
     return vcam;
 
 vcamfb_failure:
-    destroy_vcamfb(vcam);
+    vcamfb_destroy(vcam);
     vfree(vcam->fb_priv);
 video_regdev_failure:
     video_unregister_device(&vcam->vdev);
@@ -939,7 +939,7 @@ void destroy_vcam_device(struct vcam_device *vcam)
 
     if (vcam->sub_thr_id)
         kthread_stop(vcam->sub_thr_id);
-    destroy_vcamfb(vcam);
+    vcamfb_destroy(vcam);
     vfree(vcam->fb_priv);
     mutex_destroy(&vcam->vcam_mutex);
     video_unregister_device(&vcam->vdev);

--- a/device.h
+++ b/device.h
@@ -72,7 +72,7 @@ struct vcam_device {
     struct proc_dir_entry *vcam_fb_procf;
     struct mutex vcam_mutex;
 
-    /* framebuffer vcamfb_info  */
+    /* framebuffer private data */
     void *fb_priv;
 
     /* Submitter thread */

--- a/device.h
+++ b/device.h
@@ -72,6 +72,9 @@ struct vcam_device {
     struct proc_dir_entry *vcam_fb_procf;
     struct mutex vcam_mutex;
 
+    /* framebuffer vcamfb_info  */
+    void *fb_priv;
+
     /* Submitter thread */
     struct task_struct *sub_thr_id;
 

--- a/fb.c
+++ b/fb.c
@@ -1,5 +1,6 @@
 #define pr_fmt(fmt) KBUILD_MODNAME ": " fmt
 
+#include <linux/fb.h>
 #include <linux/proc_fs.h>
 #include <linux/spinlock.h>
 #include <linux/version.h>
@@ -144,4 +145,379 @@ void destroy_framebuffer(const char *proc_fname)
 
     pr_debug("Destroying framebuffer %s\n", proc_fname);
     remove_proc_entry(proc_fname, NULL);
+}
+
+static int vcam_fb_open(struct fb_info *info, int user)
+{
+    unsigned long flags = 0;
+
+    struct vcam_device *dev = info->par;
+    if (!dev) {
+        pr_err("Private data field of PDE not initilized.\n");
+        return -ENODEV;
+    }
+
+    spin_lock_irqsave(&dev->in_fh_slock, flags);
+    if (dev->fb_isopen) {
+        spin_unlock_irqrestore(&dev->in_fh_slock, flags);
+        return -EBUSY;
+    }
+    dev->fb_isopen = true;
+    spin_unlock_irqrestore(&dev->in_fh_slock, flags);
+
+    info->par = dev;
+
+    return 0;
+}
+
+static ssize_t vcam_fb_write(struct fb_info *info,
+                             const char __user *buffer,
+                             size_t length,
+                             loff_t *offset)
+{
+    struct vcam_in_queue *in_q;
+    struct vcam_in_buffer *buf;
+    size_t waiting_bytes;
+    size_t to_be_copyied;
+    unsigned long flags = 0;
+    void *data;
+
+    struct vcam_device *dev = info->par;
+    if (!dev) {
+        pr_err("Private data field of file not initialized yet.\n");
+        return 0;
+    }
+
+    waiting_bytes = dev->input_format.sizeimage;
+
+    in_q = &dev->in_queue;
+
+    buf = in_q->pending;
+    if (!buf) {
+        pr_err("Pending pointer set to NULL\n");
+        return 0;
+    }
+
+    /* Reset buffer if last write is too old */
+    if (buf->filled && (((int32_t) jiffies - buf->jiffies) / HZ)) {
+        pr_debug("Reseting jiffies, difference %d\n",
+                 ((int32_t) jiffies - buf->jiffies));
+        buf->filled = 0;
+    }
+    buf->jiffies = jiffies;
+
+    /* Fill the buffer */
+    to_be_copyied = length;
+    if ((buf->filled + to_be_copyied) > waiting_bytes)
+        to_be_copyied = waiting_bytes - buf->filled;
+
+    data = buf->data;
+    if (!data) {
+        pr_err("NULL pointer to framebuffer");
+        return 0;
+    }
+
+    if (copy_from_user(data + buf->filled, (void *) buffer, to_be_copyied) !=
+        0) {
+        pr_warn("Failed to copy_from_user!");
+    }
+    buf->filled += to_be_copyied;
+
+    if (buf->filled == waiting_bytes) {
+        spin_lock_irqsave(&dev->in_q_slock, flags);
+        swap_in_queue_buffers(in_q);
+        spin_unlock_irqrestore(&dev->in_q_slock, flags);
+    }
+
+    return to_be_copyied;
+}
+
+
+static int vcam_fb_release(struct fb_info *info, int user)
+{
+    unsigned long flags = 0;
+    struct vcam_device *dev = info->par;
+
+    spin_lock_irqsave(&dev->in_fh_slock, flags);
+    dev->fb_isopen = false;
+    spin_unlock_irqrestore(&dev->in_fh_slock, flags);
+    dev->in_queue.pending->filled = 0;
+    return 0;
+}
+
+static int vcam_fb_check_var(struct fb_var_screeninfo *var,
+                             struct fb_info *info)
+{
+    int bpp;
+    if (!var->xres)
+        var->xres = 1;
+    if (!var->yres)
+        var->yres = 1;
+    if (var->xres > var->xres_virtual)
+        var->xres_virtual = var->xres;
+    if (var->yres > var->yres_virtual)
+        var->yres_virtual = var->yres;
+
+    var->xres_virtual = var->xoffset + var->xres;
+    var->yres_virtual = var->yoffset + var->yres;
+
+    /* check bpp value ALIGN 8 */
+    bpp = var->bits_per_pixel;
+    if (bpp <= 8 || bpp > 32)
+        return -EINVAL;
+
+    var->bits_per_pixel = ALIGN(bpp, 8);
+
+    switch (var->bits_per_pixel) {
+    case 16:
+        if (var->transp.length) {
+            /* RGBA 5551 */
+            var->red.offset = 0;
+            var->red.length = 5;
+            var->green.offset = 5;
+            var->green.length = 5;
+            var->blue.offset = 10;
+            var->blue.length = 5;
+            var->transp.offset = 15;
+            var->transp.length = 1;
+        } else {
+            /* RGB 565 */
+            var->red.offset = 0;
+            var->red.length = 5;
+            var->green.offset = 5;
+            var->green.length = 6;
+            var->blue.offset = 11;
+            var->blue.length = 5;
+            var->transp.offset = 0;
+            var->transp.length = 0;
+        }
+        break;
+    case 24:
+        /* RGB 888 */
+        var->red.offset = 0;
+        var->red.length = 8;
+        var->green.offset = 8;
+        var->green.length = 8;
+        var->blue.offset = 16;
+        var->blue.length = 8;
+        var->transp.offset = 0;
+        var->transp.length = 0;
+        break;
+    case 32:
+        /* RGBA 8888 */
+        var->red.offset = 0;
+        var->red.length = 8;
+        var->green.offset = 8;
+        var->green.length = 8;
+        var->blue.offset = 16;
+        var->blue.length = 8;
+        var->transp.offset = 24;
+        var->transp.length = 8;
+        break;
+    }
+    var->red.msb_right = 0;
+    var->green.msb_right = 0;
+    var->blue.msb_right = 0;
+    var->transp.msb_right = 0;
+
+    return 0;
+}
+
+static int vcam_fb_set_par(struct fb_info *info)
+{
+    info->fix.visual = FB_VISUAL_TRUECOLOR;
+    return 0;
+}
+
+static int vcam_fb_mmap(struct fb_info *info, struct vm_area_struct *vma)
+{
+    int ret =
+        remap_vmalloc_range(vma, (void *) info->fix.smem_start, vma->vm_pgoff);
+    if (ret < 0)
+        return -EINVAL;
+    ret = remap_vmalloc_range(
+        vma, (void *) info->fix.smem_start + info->fix.smem_len, vma->vm_pgoff);
+    if (ret < 0)
+        return -EINVAL;
+    return 0;
+}
+
+static int vcam_fb_setcolreg(u_int regno,
+                             u_int red,
+                             u_int green,
+                             u_int blue,
+                             u_int transp,
+                             struct fb_info *info)
+{
+    if (regno >= 256)
+        return -EINVAL;
+    if (info->fix.visual == FB_VISUAL_TRUECOLOR) {
+        u32 color;
+
+        if (regno >= 16)
+            return -EINVAL;
+
+        color = (red << info->var.red.offset) |
+                (green << info->var.green.offset) |
+                (blue << info->var.blue.offset) |
+                (transp << info->var.transp.offset);
+
+        ((u32 *) (info->pseudo_palette))[regno] = color;
+    }
+    return 0;
+}
+
+static const struct fb_ops vcamfb_ops = {
+    .fb_open = vcam_fb_open,
+    .fb_release = vcam_fb_release,
+    .fb_write = vcam_fb_write,
+    .fb_set_par = vcam_fb_set_par,
+    .fb_check_var = vcam_fb_check_var,
+    .fb_setcolreg = vcam_fb_setcolreg,
+    .fb_mmap = vcam_fb_mmap,
+};
+
+static struct fb_fix_screeninfo vfb_fix = {
+    .id = "vcamfb",
+    .type = FB_TYPE_PACKED_PIXELS,
+    .visual = FB_VISUAL_TRUECOLOR,
+    .xpanstep = 1,
+    .ypanstep = 1,
+    .ywrapstep = 1,
+    .accel = FB_ACCEL_NONE,
+};
+
+static struct fb_var_screeninfo vfb_default = {
+    .pixclock = 0,
+    .left_margin = 0,
+    .right_margin = 0,
+    .upper_margin = 0,
+    .lower_margin = 0,
+    .hsync_len = 0,
+    .vsync_len = 0,
+    .vmode = FB_VMODE_NONINTERLACED,
+};
+
+int init_vcamfb(struct vcam_device *dev)
+{
+    struct vcamfb_info *fb_data;
+    struct vcam_in_queue *q = &dev->in_queue;
+    struct fb_info *info;
+    unsigned int size;
+    int ret;
+
+    /* malloc vcamfb_info */
+    fb_data = vmalloc(sizeof(struct vcamfb_info));
+    dev->fb_priv = (void *) fb_data;
+    info = &fb_data->info;
+
+    /* malloc framebuffer and init framebuffer */
+    size = dev->input_format.sizeimage * 2;
+    if (!(fb_data->addr = vmalloc(size)))
+        return -ENOMEM;
+    fb_data->offset = dev->input_format.sizeimage;
+    q->buffers[0].data = fb_data->addr;
+    q->buffers[0].filled = 0;
+    q->buffers[1].data = (void *) (fb_data->addr + fb_data->offset);
+    q->buffers[1].filled = 0;
+    memset(&q->dummy, 0, sizeof(struct vcam_in_buffer));
+    q->pending = &q->buffers[0];
+    q->ready = &q->buffers[1];
+
+    /* set the fb_fix */
+    vfb_fix.smem_len = dev->input_format.sizeimage;
+    vfb_fix.smem_start = (unsigned long) fb_data->addr;
+    vfb_fix.line_length = dev->input_format.bytesperline;
+
+    /* set the fb_var */
+    vfb_default.xres = dev->input_format.width;
+    vfb_default.yres = dev->input_format.height;
+    vfb_default.bits_per_pixel = 24;
+    vcam_fb_check_var(&vfb_default, info);
+
+    /* set the fb_info */
+    info->screen_base = (char __iomem *) fb_data->addr;
+    info->fix = vfb_fix;
+    info->var = vfb_default;
+    info->fbops = &vcamfb_ops;
+    info->par = dev;
+    info->pseudo_palette = NULL;
+    info->flags = FBINFO_FLAG_DEFAULT;
+
+    ret = fb_alloc_cmap(&info->cmap, 256, 0);
+    if (ret < 0)
+        return -EINVAL;
+
+    ret = register_framebuffer(info);
+    if (ret < 0)
+        goto fb_alloc_failure;
+
+    snprintf(fb_data->fb_name, sizeof(fb_data->fb_name), "fb%d",
+             MINOR(info->dev->devt));
+
+    return 0;
+
+fb_alloc_failure:
+    fb_dealloc_cmap(&info->cmap);
+    return -EINVAL;
+}
+
+void destroy_vcamfb(struct vcam_device *dev)
+{
+    struct vcamfb_info *fb_data = (struct vcamfb_info *) dev->fb_priv;
+    struct fb_info *info = &fb_data->info;
+    if (info) {
+        unregister_framebuffer(info);
+        vfree(fb_data->addr);
+        fb_dealloc_cmap(&info->cmap);
+    }
+}
+
+void vcam_update_vcamfb(struct vcam_device *dev)
+{
+    struct vcamfb_info *fb_data = (struct vcamfb_info *) dev->fb_priv;
+    struct fb_info *info = &fb_data->info;
+    struct vcam_in_queue *q = &dev->in_queue;
+
+    /* check input_format */
+    if (dev->input_format.width != dev->output_format.width) {
+        dev->input_format.width = dev->output_format.width;
+        dev->input_format.height = dev->output_format.height;
+        dev->input_format.bytesperline = dev->output_format.bytesperline;
+        dev->input_format.sizeimage =
+            dev->input_format.height * dev->input_format.bytesperline;
+    }
+
+    /* remalloc the framebuffer */
+    if (info->var.xres_virtual != dev->output_format.width) {
+        unsigned int size;
+        vfree(fb_data->addr);
+        fb_data->offset = dev->input_format.sizeimage;
+        size = dev->input_format.sizeimage * 2;
+        fb_data->addr = vmalloc(size);
+        q->buffers[0].data = fb_data->addr;
+        q->buffers[1].data = (void *) (fb_data->addr + fb_data->offset);
+        q->buffers[0].filled = 0;
+        q->buffers[1].filled = 0;
+        memset(&q->dummy, 0, sizeof(struct vcam_in_buffer));
+
+        /* reset the fb_fix */
+        info->fix.smem_len = dev->input_format.sizeimage;
+        info->fix.smem_start = (unsigned long) fb_data->addr;
+
+        /* reset the fb_info */
+        info->screen_base = (char __iomem *) fb_data->addr;
+    }
+
+    /* reset the fb_var and fb_fix */
+    if (dev->conv_crop_on) {
+        info->var.xres = dev->crop_output_format.width;
+        info->var.yres = dev->crop_output_format.height;
+    } else {
+        info->var.xres = dev->output_format.width;
+        info->var.yres = dev->output_format.height;
+    }
+    info->var.xres_virtual = dev->input_format.width;
+    info->var.yres_virtual = dev->input_format.height;
+    info->fix.line_length = dev->input_format.bytesperline;
 }

--- a/fb.c
+++ b/fb.c
@@ -477,6 +477,7 @@ void vcamfb_destroy(struct vcam_device *dev)
         unregister_framebuffer(info);
         vfree(fb_data->addr);
         fb_dealloc_cmap(&info->cmap);
+        vfree(dev->fb_priv);
     }
 }
 

--- a/fb.c
+++ b/fb.c
@@ -8,6 +8,13 @@
 #include "fb.h"
 #include "videobuf.h"
 
+struct vcamfb_info {
+    struct fb_info info;
+    void *addr;
+    unsigned int offset;
+    char name[FB_NAME_MAXLENGTH];
+};
+
 static int vcamfb_open(struct inode *ind, struct file *file)
 {
     unsigned long flags = 0;
@@ -452,7 +459,7 @@ int init_vcamfb(struct vcam_device *dev)
     if (ret < 0)
         goto fb_alloc_failure;
 
-    snprintf(fb_data->fb_name, sizeof(fb_data->fb_name), "fb%d",
+    snprintf(fb_data->name, sizeof(fb_data->name), "fb%d",
              MINOR(info->dev->devt));
 
     return 0;
@@ -473,7 +480,7 @@ void destroy_vcamfb(struct vcam_device *dev)
     }
 }
 
-void vcam_update_vcamfb(struct vcam_device *dev)
+void update_vcamfb_format(struct vcam_device *dev)
 {
     struct vcamfb_info *fb_data = (struct vcamfb_info *) dev->fb_priv;
     struct fb_info *info = &fb_data->info;
@@ -520,4 +527,11 @@ void vcam_update_vcamfb(struct vcam_device *dev)
     info->var.xres_virtual = dev->input_format.width;
     info->var.yres_virtual = dev->input_format.height;
     info->fix.line_length = dev->input_format.bytesperline;
+}
+
+char *get_vcamfb_name(struct vcam_device *dev)
+{
+    struct vcamfb_info *fb_data;
+    fb_data = dev->fb_priv;
+    return fb_data->name;
 }

--- a/fb.c
+++ b/fb.c
@@ -405,7 +405,7 @@ static struct fb_var_screeninfo vfb_default = {
     .vmode = FB_VMODE_NONINTERLACED,
 };
 
-int init_vcamfb(struct vcam_device *dev)
+int vcamfb_init(struct vcam_device *dev)
 {
     struct vcamfb_info *fb_data;
     struct vcam_in_queue *q = &dev->in_queue;
@@ -469,7 +469,7 @@ fb_alloc_failure:
     return -EINVAL;
 }
 
-void destroy_vcamfb(struct vcam_device *dev)
+void vcamfb_destroy(struct vcam_device *dev)
 {
     struct vcamfb_info *fb_data = (struct vcamfb_info *) dev->fb_priv;
     struct fb_info *info = &fb_data->info;
@@ -480,7 +480,7 @@ void destroy_vcamfb(struct vcam_device *dev)
     }
 }
 
-void update_vcamfb_format(struct vcam_device *dev)
+void vcamfb_update(struct vcam_device *dev)
 {
     struct vcamfb_info *fb_data = (struct vcamfb_info *) dev->fb_priv;
     struct fb_info *info = &fb_data->info;
@@ -529,7 +529,7 @@ void update_vcamfb_format(struct vcam_device *dev)
     info->fix.line_length = dev->input_format.bytesperline;
 }
 
-char *get_vcamfb_name(struct vcam_device *dev)
+char *vcamfb_get_devname(struct vcam_device *dev)
 {
     struct vcamfb_info *fb_data;
     fb_data = dev->fb_priv;

--- a/fb.h
+++ b/fb.h
@@ -1,25 +1,14 @@
 #ifndef VCAM_FB_H
 #define VCAM_FB_H
 
-#include <linux/fb.h>
-
 #include "device.h"
-
-struct proc_dir_entry *init_framebuffer(const char *proc_fname,
-                                        struct vcam_device *dev);
-void destroy_framebuffer(const char *proc_fname);
 
 int init_vcamfb(struct vcam_device *dev);
 
 void destroy_vcamfb(struct vcam_device *dev);
 
-void vcam_update_vcamfb(struct vcam_device *dev);
+void update_vcamfb_format(struct vcam_device *dev);
 
-struct vcamfb_info {
-    struct fb_info info;
-    void *addr;
-    unsigned int offset;
-    char fb_name[FB_NAME_MAXLENGTH];
-};
+char *get_vcamfb_name(struct vcam_device *dev);
 
 #endif

--- a/fb.h
+++ b/fb.h
@@ -3,12 +3,12 @@
 
 #include "device.h"
 
-int init_vcamfb(struct vcam_device *dev);
+int vcamfb_init(struct vcam_device *dev);
 
-void destroy_vcamfb(struct vcam_device *dev);
+void vcamfb_destroy(struct vcam_device *dev);
 
-void update_vcamfb_format(struct vcam_device *dev);
+void vcamfb_update(struct vcam_device *dev);
 
-char *get_vcamfb_name(struct vcam_device *dev);
+char *vcamfb_get_devname(struct vcam_device *dev);
 
 #endif

--- a/fb.h
+++ b/fb.h
@@ -1,10 +1,25 @@
 #ifndef VCAM_FB_H
 #define VCAM_FB_H
 
+#include <linux/fb.h>
+
 #include "device.h"
 
 struct proc_dir_entry *init_framebuffer(const char *proc_fname,
                                         struct vcam_device *dev);
 void destroy_framebuffer(const char *proc_fname);
+
+int init_vcamfb(struct vcam_device *dev);
+
+void destroy_vcamfb(struct vcam_device *dev);
+
+void vcam_update_vcamfb(struct vcam_device *dev);
+
+struct vcamfb_info {
+    struct fb_info info;
+    void *addr;
+    unsigned int offset;
+    char fb_name[FB_NAME_MAXLENGTH];
+};
 
 #endif


### PR DESCRIPTION
In the original version, vcam_in_queue_setup() called
vmalloc twice for frame buffers, and we can't know what
size are buffers.This patch main includes
register_framebuffer() and replaces vcam_in_queue_setup()
in vcam initiated. It defaults frame buffer 640 * 480
and resizes the frame buffer when scaling ON.

To check the frame buffer information, use the following command:
$ sudo fbset -fb /dev/fb1 --info

```
mode "640x480"
    geometry 640 480 640 480 24
    timings 0 0 0 0 0 0 0
    rgba 8/0,8/8,8/16,0/0
endmode

Frame buffer device information:
    Name        : vcamfb
    Address     : 0xffffb5a6427d1000
    Size        : 921600
    Type        : PACKED PIXELS
    Visual      : TRUECOLOR
    XPanStep    : 1
    YPanStep    : 1
    YWrapStep   : 1
    LineLength  : 1920
    Accelerator : No
```
after the scaling ON
```
mode "1280x720"
    geometry 1280 720 1280 720 24
    timings 0 0 0 0 0 0 0
    rgba 8/0,8/8,8/16,0/0
endmode

Frame buffer device information:
    Name        : vcamfb
    Address     : 0xffffb5a646985000
    Size        : 2764800
    Type        : PACKED PIXELS
    Visual      : TRUECOLOR
    XPanStep    : 1
    YPanStep    : 1
    YWrapStep   : 1
    LineLength  : 3840
    Accelerator : No
```