### PR TITLE
Add --fbdev option in vcam-util

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,19 @@ You should get:
 Available virtual V4L2 compatible devices:
 1. fbX(640,480,rgb24) -> /dev/video0
 ```
+Another e.g. list all available framebuffer device(s) information:
+```shell
+$ sudo ./vcam-util -f
+```
+
+You should get:
+```
+Available framebuffer device information:
+1. vcamfb(640/480/640/480)
+Size        :921600
+Address     :0xffffb1ab03d1d000
+LineLength  :1920
+```
 
 You can use this command to check if the driver is ok:
 ```shell
@@ -91,7 +104,7 @@ $ sudo fbset -fb /dev/fbX --info
 ```
 
 You will get information as following:
-```shell
+```
 mode "640x480"
     geometry 640 480 640 480 24
     timings 0 0 0 0 0 0 0

--- a/README.md
+++ b/README.md
@@ -67,9 +67,9 @@ You should get:
 ```
 Available framebuffer device information:
 1. vcamfb(640/480/640/480)
-Size        :921600
-Address     :0xffffb1ab03d1d000
-LineLength  :1920
+Size        : 921600
+Address     : 0xffffb1ab03aad000
+LineLength  : 1920
 ```
 
 You can use this command to check if the driver is ok:

--- a/control.c
+++ b/control.c
@@ -84,6 +84,19 @@ static int control_iocontrol_get_device(struct vcam_device_spec *dev_spec)
     return 0;
 }
 
+static int control_iocontrol_get_fb(struct vcam_device_spec *dev_spec)
+{
+    struct vcam_device *dev;
+    int ret;
+
+    if (ctldev->vcam_device_count <= dev_spec->idx)
+        return -EINVAL;
+
+    dev = ctldev->vcam_devices[dev_spec->idx];
+    ret = vcamfb_get_info(dev, dev_spec);
+    return 0;
+}
+
 static int control_iocontrol_modify_input_setting(
     struct vcam_device_spec *dev_spec)
 {
@@ -202,6 +215,17 @@ static long control_ioctl(struct file *file,
     case VCAM_IOCTL_MODIFY_SETTING:
         pr_debug("Modify setting(%d)\n", dev_spec.idx);
         ret = control_iocontrol_modify_input_setting(&dev_spec);
+        break;
+    case VCAM_IOCTL_GET_FB:
+        pr_debug("Get device(%d)\n", dev_spec.idx);
+        ret = control_iocontrol_get_fb(&dev_spec);
+        if (!ret) {
+            if (copy_to_user((void *__user *) iocontrol_param, &dev_spec,
+                             sizeof(struct vcam_device_spec)) != 0) {
+                pr_warn("Failed to copy_to_user!");
+                ret = -1;
+            }
+        }
         break;
     default:
         ret = -1;

--- a/control.c
+++ b/control.c
@@ -94,7 +94,7 @@ static int control_iocontrol_get_fb(struct vcam_device_spec *dev_spec)
 
     dev = ctldev->vcam_devices[dev_spec->idx];
     ret = vcamfb_get_info(dev, dev_spec);
-    return 0;
+    return ret;
 }
 
 static int control_iocontrol_modify_input_setting(
@@ -219,12 +219,12 @@ static long control_ioctl(struct file *file,
     case VCAM_IOCTL_GET_FB:
         pr_debug("Get device(%d)\n", dev_spec.idx);
         ret = control_iocontrol_get_fb(&dev_spec);
-        if (!ret) {
-            if (copy_to_user((void *__user *) iocontrol_param, &dev_spec,
-                             sizeof(struct vcam_device_spec)) != 0) {
-                pr_warn("Failed to copy_to_user!");
-                ret = -1;
-            }
+        if (ret)
+            break;
+        if (copy_to_user((void *__user *) iocontrol_param, &dev_spec,
+                         sizeof(struct vcam_device_spec)) != 0) {
+            pr_warn("Failed to copy_to_user!");
+            ret = -1;
         }
         break;
     default:

--- a/fb.c
+++ b/fb.c
@@ -536,3 +536,18 @@ char *vcamfb_get_devname(struct vcam_device *dev)
     fb_data = dev->fb_priv;
     return fb_data->name;
 }
+
+int vcamfb_get_info(struct vcam_device *dev, struct vcam_device_spec *dev_spec)
+{
+    struct vcamfb_info *fb_data = (struct vcamfb_info *) dev->fb_priv;
+    struct fb_info *info = &fb_data->info;
+    dev_spec->width = info->var.xres;
+    dev_spec->height = info->var.yres;
+    dev_spec->virt_width = info->var.xres_virtual;
+    dev_spec->virt_height = info->var.yres_virtual;
+    dev_spec->address = fb_data->addr;
+    dev_spec->mem_len = info->fix.smem_len;
+    dev_spec->perline = info->fix.line_length;
+    strncpy(dev_spec->fb_id, info->fix.id, sizeof(dev_spec->fb_id));
+    return 0;
+}

--- a/fb.h
+++ b/fb.h
@@ -11,4 +11,6 @@ void vcamfb_update(struct vcam_device *dev);
 
 char *vcamfb_get_devname(struct vcam_device *dev);
 
+int vcamfb_get_info(struct vcam_device *dev, struct vcam_device_spec *dev_spec);
+
 #endif

--- a/vcam-util.c
+++ b/vcam-util.c
@@ -167,8 +167,10 @@ int list_fb()
     while (!ioctl(fd, VCAM_IOCTL_GET_FB, &dev)) {
         dev.idx++;
         printf(
-            "%d. %s(%d/%d/%d/%d)\nSize        :%d\nAddress     :%p\nLineLength "
-            " :%d\n",
+            "%d. %s(%d/%d/%d/%d)\n"
+            "Size        : %d\n"
+            "Address     : %p\n"
+            "LineLength  : %d\n",
             dev.idx, dev.fb_id, dev.width, dev.height, dev.virt_width,
             dev.virt_height, dev.mem_len, dev.address, dev.perline);
     }

--- a/vcam.h
+++ b/vcam.h
@@ -6,6 +6,7 @@
 #define VCAM_IOCTL_GET_DEVICE 0x333
 #define VCAM_IOCTL_ENUM_DEVICES 0x444
 #define VCAM_IOCTL_MODIFY_SETTING 0x555
+#define VCAM_IOCTL_GET_FB 0x666
 
 typedef enum { VCAM_PIXFMT_RGB24 = 0x01, VCAM_PIXFMT_YUYV = 0x02 } pixfmt_t;
 
@@ -15,6 +16,13 @@ struct vcam_device_spec {
     pixfmt_t pix_fmt;
     char video_node[64];
     char fb_node[64];
+
+    /* vcamfb_spec  */
+    char fb_id[64];
+    unsigned short virt_width, virt_height;
+    void *address;
+    unsigned int mem_len;
+    unsigned int perline;
 };
 
 #endif


### PR DESCRIPTION
It was unable get the framebuffer device information.
This patch register an option which the vcam-util
can show the framebuffer device information.

To check the fbdev option, used the following command:

$ sudo ./vcam-util -f
```
Available framebuffer device information:
1. vcamfb(640/480/640/480)
Size        :921600
Address     :0xffffba3bc3c9d000
LineLength  :1920
```