### PR TITLE
Fix the memory leak in vcam

### DIFF
--- a/control.c
+++ b/control.c
@@ -77,7 +77,7 @@ static int control_iocontrol_get_device(struct vcam_device_spec *dev_spec)
     else
         dev_spec->pix_fmt = VCAM_PIXFMT_RGB24;
 
-    strncpy((char *) &dev_spec->fb_node, (const char *) vcamfb_get_devname(dev),
+    strncpy((char *) &dev_spec->fb_node, (const char *) vcamfb_get_devnode(dev),
             sizeof(dev_spec->fb_node));
     snprintf((char *) &dev_spec->video_node, sizeof(dev_spec->video_node),
              "/dev/video%d", dev->vdev.minor);

--- a/device.c
+++ b/device.c
@@ -510,7 +510,7 @@ static void submit_noinput_buffer(struct vcam_out_buffer *buf,
     int i, j;
     int32_t yuyv_tmp;
     unsigned char *yuyv_helper = (unsigned char *) &yuyv_tmp;
-    void *vbuf_ptr = vb2_plane_vaddr(&buf->vb, 0);
+    void *vbuf_ptr = vb2_plane_vaddr(&buf->vb.vb2_buf, 0);
     int32_t *yuyv_ptr = vbuf_ptr;
     size_t size = dev->output_format.sizeimage;
     size_t rowsize = dev->output_format.bytesperline;
@@ -544,8 +544,8 @@ static void submit_noinput_buffer(struct vcam_out_buffer *buf,
             memset(vbuf_ptr, 0xff, rowsize * (rows % 255));
     }
 
-    buf->vb.timestamp = ktime_get_ns();
-    vb2_buffer_done(&buf->vb, VB2_BUF_STATE_DONE);
+    buf->vb.vb2_buf.timestamp = ktime_get_ns();
+    vb2_buffer_done(&buf->vb.vb2_buf, VB2_BUF_STATE_DONE);
 }
 
 static void copy_scale(unsigned char *dst,
@@ -681,7 +681,7 @@ static void submit_copy_buffer(struct vcam_out_buffer *out_buf,
         pr_err("Input buffer is NULL in ready state\n");
         return;
     }
-    out_vbuf_ptr = vb2_plane_vaddr(&out_buf->vb, 0);
+    out_vbuf_ptr = vb2_plane_vaddr(&out_buf->vb.vb2_buf, 0);
     if (!out_vbuf_ptr) {
         pr_err("Output buffer is NULL\n");
         return;
@@ -724,8 +724,8 @@ static void submit_copy_buffer(struct vcam_out_buffer *out_buf,
             }
         }
     }
-    out_buf->vb.timestamp = ktime_get_ns();
-    vb2_buffer_done(&out_buf->vb, VB2_BUF_STATE_DONE);
+    out_buf->vb.vb2_buf.timestamp = ktime_get_ns();
+    vb2_buffer_done(&out_buf->vb.vb2_buf, VB2_BUF_STATE_DONE);
 }
 
 int submitter_thread(void *data)

--- a/device.h
+++ b/device.h
@@ -6,6 +6,7 @@
 #include <media/v4l2-device.h>
 #include <media/v4l2-ioctl.h>
 #include <media/videobuf2-core.h>
+#include <media/videobuf2-v4l2.h>
 
 #include "vcam.h"
 
@@ -32,7 +33,7 @@ struct vcam_in_queue {
 };
 
 struct vcam_out_buffer {
-    struct vb2_buffer vb;
+    struct vb2_v4l2_buffer vb;
     struct list_head list;
     size_t filled;
 };

--- a/fb.c
+++ b/fb.c
@@ -530,7 +530,7 @@ void vcamfb_update(struct vcam_device *dev)
     info->fix.line_length = dev->input_format.bytesperline;
 }
 
-char *vcamfb_get_devname(struct vcam_device *dev)
+char *vcamfb_get_devnode(struct vcam_device *dev)
 {
     struct vcamfb_info *fb_data;
     fb_data = dev->fb_priv;

--- a/fb.c
+++ b/fb.c
@@ -374,7 +374,7 @@ static int vcam_fb_setcolreg(u_int regno,
     return 0;
 }
 
-static const struct fb_ops vcamfb_ops = {
+static struct fb_ops vcamfb_ops = {
     .fb_open = vcam_fb_open,
     .fb_release = vcam_fb_release,
     .fb_write = vcam_fb_write,

--- a/fb.c
+++ b/fb.c
@@ -375,6 +375,7 @@ static int vcam_fb_setcolreg(u_int regno,
 }
 
 static struct fb_ops vcamfb_ops = {
+    .owner = THIS_MODULE,
     .fb_open = vcam_fb_open,
     .fb_release = vcam_fb_release,
     .fb_write = vcam_fb_write,
@@ -450,10 +451,19 @@ int vcamfb_init(struct vcam_device *dev)
     info->par = dev;
     info->pseudo_palette = NULL;
     info->flags = FBINFO_FLAG_DEFAULT;
+    info->device = &dev->vdev.dev;
+    INIT_LIST_HEAD(&info->modelist);
 
-    ret = fb_alloc_cmap(&info->cmap, 256, 0);
-    if (ret < 0)
-        return -EINVAL;
+    /* set the fb_cmap */
+    info->cmap.red = NULL;
+    info->cmap.green = NULL;
+    info->cmap.blue = NULL;
+    info->cmap.transp = NULL;
+
+    if (fb_alloc_cmap(&info->cmap, 256, 0)) {
+        pr_err("unable to alloc cmap");
+        return -ENOMEM;
+    }
 
     ret = register_framebuffer(info);
     if (ret < 0)

--- a/fb.h
+++ b/fb.h
@@ -9,6 +9,6 @@ void vcamfb_destroy(struct vcam_device *dev);
 
 void vcamfb_update(struct vcam_device *dev);
 
-char *vcamfb_get_devname(struct vcam_device *dev);
+char *vcamfb_get_devnode(struct vcam_device *dev);
 
 #endif

--- a/videobuf.c
+++ b/videobuf.c
@@ -109,7 +109,8 @@ static void vcam_out_buffer_queue(struct vb2_buffer *vb)
 {
     unsigned long flags = 0;
     struct vcam_device *dev = vb2_get_drv_priv(vb->vb2_queue);
-    struct vcam_out_buffer *buf = container_of(vb, struct vcam_out_buffer, vb);
+    struct vb2_v4l2_buffer *vb2 = to_vb2_v4l2_buffer(vb);
+    struct vcam_out_buffer *buf = container_of(vb2, struct vcam_out_buffer, vb);
     struct vcam_out_queue *q = &dev->vcam_out_vidq;
     buf->filled = 0;
 
@@ -151,7 +152,7 @@ static void vcam_stop_streaming(struct vb2_queue *vb2_q)
         struct vcam_out_buffer *buf =
             list_entry(q->active.next, struct vcam_out_buffer, list);
         list_del(&buf->list);
-        vb2_buffer_done(&buf->vb, VB2_BUF_STATE_ERROR);
+        vb2_buffer_done(&buf->vb.vb2_buf, VB2_BUF_STATE_ERROR);
         pr_debug("Throwing out buffer\n");
     }
     spin_unlock_irqrestore(&dev->out_q_slock, flags);


### PR DESCRIPTION
I checked from the KASAN. It had an slab-out-of-bounds
in __init_vb2_v4l2_buffer+0x19/0x30 [videobuf2_v4l2].
In __init_vb2_v4l2_buffer which is called vb2_queue_init()
, it use the to_vb2_v4l2_buffer()from the vb2_buffer to
vb2_v4l2_buffer, but vcam_out_buffer didn't have
this member. I restructure the vcam_out_buffer's
member from vb2_buffer to vb2_v4l2_buffer.

