### PR TITLE
Fix the memory leak

### DIFF
--- a/device.c
+++ b/device.c
@@ -510,7 +510,7 @@ static void submit_noinput_buffer(struct vcam_out_buffer *buf,
     int i, j;
     int32_t yuyv_tmp;
     unsigned char *yuyv_helper = (unsigned char *) &yuyv_tmp;
-    void *vbuf_ptr = vb2_plane_vaddr(&buf->vb, 0);
+    void *vbuf_ptr = vb2_plane_vaddr(&buf->vb.vb2_buf, 0);
     int32_t *yuyv_ptr = vbuf_ptr;
     size_t size = dev->output_format.sizeimage;
     size_t rowsize = dev->output_format.bytesperline;
@@ -544,8 +544,8 @@ static void submit_noinput_buffer(struct vcam_out_buffer *buf,
             memset(vbuf_ptr, 0xff, rowsize * (rows % 255));
     }
 
-    buf->vb.timestamp = ktime_get_ns();
-    vb2_buffer_done(&buf->vb, VB2_BUF_STATE_DONE);
+    buf->vb.vb2_buf.timestamp = ktime_get_ns();
+    vb2_buffer_done(&buf->vb.vb2_buf, VB2_BUF_STATE_DONE);
 }
 
 static void copy_scale(unsigned char *dst,
@@ -681,7 +681,7 @@ static void submit_copy_buffer(struct vcam_out_buffer *out_buf,
         pr_err("Input buffer is NULL in ready state\n");
         return;
     }
-    out_vbuf_ptr = vb2_plane_vaddr(&out_buf->vb, 0);
+    out_vbuf_ptr = vb2_plane_vaddr(&out_buf->vb.vb2_buf, 0);
     if (!out_vbuf_ptr) {
         pr_err("Output buffer is NULL\n");
         return;
@@ -724,8 +724,8 @@ static void submit_copy_buffer(struct vcam_out_buffer *out_buf,
             }
         }
     }
-    out_buf->vb.timestamp = ktime_get_ns();
-    vb2_buffer_done(&out_buf->vb, VB2_BUF_STATE_DONE);
+    out_buf->vb.vb2_buf.timestamp = ktime_get_ns();
+    vb2_buffer_done(&out_buf->vb.vb2_buf, VB2_BUF_STATE_DONE);
 }
 
 int submitter_thread(void *data)

--- a/device.h
+++ b/device.h
@@ -6,6 +6,7 @@
 #include <media/v4l2-device.h>
 #include <media/v4l2-ioctl.h>
 #include <media/videobuf2-core.h>
+#include <media/videobuf2-v4l2.h>
 
 #include "vcam.h"
 
@@ -32,7 +33,7 @@ struct vcam_in_queue {
 };
 
 struct vcam_out_buffer {
-    struct vb2_buffer vb;
+    struct vb2_v4l2_buffer vb;
     struct list_head list;
     size_t filled;
 };

--- a/fb.c
+++ b/fb.c
@@ -375,6 +375,7 @@ static int vcam_fb_setcolreg(u_int regno,
 }
 
 static struct fb_ops vcamfb_ops = {
+    .owner = THIS_MODULE,
     .fb_open = vcam_fb_open,
     .fb_release = vcam_fb_release,
     .fb_write = vcam_fb_write,
@@ -450,10 +451,19 @@ int vcamfb_init(struct vcam_device *dev)
     info->par = dev;
     info->pseudo_palette = NULL;
     info->flags = FBINFO_FLAG_DEFAULT;
+    info->device = &dev->vdev.dev;
+    INIT_LIST_HEAD(&info->modelist);
 
-    ret = fb_alloc_cmap(&info->cmap, 256, 0);
-    if (ret < 0)
-        return -EINVAL;
+    /* set the fb_cmap */
+    info->cmap.red = NULL;
+    info->cmap.green = NULL;
+    info->cmap.blue = NULL;
+    info->cmap.transp = NULL;
+
+    if (fb_alloc_cmap(&info->cmap, 256, 0)) {
+        pr_err("Failed to allocate cmap!");
+        return -ENOMEM;
+    }
 
     ret = register_framebuffer(info);
     if (ret < 0)

--- a/videobuf.c
+++ b/videobuf.c
@@ -109,7 +109,9 @@ static void vcam_out_buffer_queue(struct vb2_buffer *vb)
 {
     unsigned long flags = 0;
     struct vcam_device *dev = vb2_get_drv_priv(vb->vb2_queue);
-    struct vcam_out_buffer *buf = container_of(vb, struct vcam_out_buffer, vb);
+    struct vb2_v4l2_buffer *vbuf = to_vb2_v4l2_buffer(vb);
+    struct vcam_out_buffer *buf =
+        container_of(vbuf, struct vcam_out_buffer, vb);
     struct vcam_out_queue *q = &dev->vcam_out_vidq;
     buf->filled = 0;
 
@@ -151,7 +153,7 @@ static void vcam_stop_streaming(struct vb2_queue *vb2_q)
         struct vcam_out_buffer *buf =
             list_entry(q->active.next, struct vcam_out_buffer, list);
         list_del(&buf->list);
-        vb2_buffer_done(&buf->vb, VB2_BUF_STATE_ERROR);
+        vb2_buffer_done(&buf->vb.vb2_buf, VB2_BUF_STATE_ERROR);
         pr_debug("Throwing out buffer\n");
     }
     spin_unlock_irqrestore(&dev->out_q_slock, flags);


### PR DESCRIPTION
The `__init_vb2_v4l2_buffer()` is called by `vb2_queue_init()`.
`__init_vb2_v4l2_buffer()` is a `to_vb2_v4l2_buffer()` which is
a `container_of()` from the `struct vb2_buffer` to `struct vb2_v4l2_buffer`.
This patch restructures the vcam_out_buffer's member from `vb2_buffer`
to `vb2_v4l2_buffer` to solve this problem.
```
[ 1782.469808] ==================================================================
[ 1782.469828] BUG: KASAN: slab-out-of-bounds in __init_vb2_v4l2_buffer+0x19/0x30 [videobuf2_v4l2]
[ 1782.469831] Write of size 4 at addr ffff88814e99a21c by task vlc/8923

[ 1782.469837] CPU: 3 PID: 8923 Comm: vlc Tainted: G           OE     5.8.6 #1
[ 1782.469839] Hardware name: innotek GmbH VirtualBox/VirtualBox, BIOS VirtualBox 12/01/2006
[ 1782.469840] Call Trace:
[ 1782.469858]  dump_stack+0x9d/0xda
[ 1782.469863]  print_address_description.constprop.0+0x1f/0x210
[ 1782.469867]  ? _raw_spin_lock_irqsave+0x8e/0xf0
[ 1782.469869]  ? _raw_spin_trylock_bh+0x100/0x100
[ 1782.469875]  ? __init_vb2_v4l2_buffer+0x19/0x30 [videobuf2_v4l2]
[ 1782.469877]  kasan_report.cold+0x37/0x7c
[ 1782.469882]  ? __init_vb2_v4l2_buffer+0x19/0x30 [videobuf2_v4l2]
[ 1782.469886]  __asan_store4+0x8b/0xb0
[ 1782.469890]  __init_vb2_v4l2_buffer+0x19/0x30 [videobuf2_v4l2]
[ 1782.469897]  __vb2_queue_alloc+0x1d3/0x660 [videobuf2_common]
[ 1782.469904]  vb2_core_reqbufs+0x45a/0x690 [videobuf2_common]
[ 1782.469911]  ? vb2_core_streamoff+0xa0/0xa0 [videobuf2_common]
[ 1782.469913]  ? kasan_unpoison_shadow+0x38/0x50
[ 1782.469916]  ? __kasan_kmalloc.constprop.0+0xcf/0xe0
[ 1782.469918]  ? kasan_kmalloc+0x9/0x10
[ 1782.469920]  ? kmem_cache_alloc_trace+0x128/0x2a0
[ 1782.469935]  __vb2_init_fileio+0x189/0x470 [videobuf2_common]
[ 1782.469942]  vb2_core_poll+0x260/0x320 [videobuf2_common]
[ 1782.469947]  vb2_poll+0x34/0xd0 [videobuf2_v4l2]
[ 1782.469952]  vb2_fop_poll+0x9f/0x1b0 [videobuf2_v4l2]
[ 1782.469974]  v4l2_poll+0xf2/0x110 [videodev]
[ 1782.469978]  do_sys_poll+0x454/0x780
[ 1782.469982]  ? compat_core_sys_select+0x3f0/0x3f0
[ 1782.469985]  ? stack_trace_save+0x94/0xc0
[ 1782.469989]  ? ftrace_graph_ret_addr+0x2a/0xb0
[ 1782.469992]  ? entry_SYSCALL_64_after_hwframe+0x44/0xa9
[ 1782.469995]  ? update_stack_state+0x1f4/0x2b0
[ 1782.469999]  ? bpf_ksym_find+0x9e/0xf0
[ 1782.470001]  ? is_bpf_text_address+0xe/0x20
[ 1782.470005]  ? kernel_text_address+0xfe/0x110
[ 1782.470007]  ? __kasan_check_write+0x14/0x20
[ 1782.470010]  ? __pv_queued_spin_lock_slowpath+0x2de/0x580
[ 1782.470012]  ? pv_hash+0xe0/0xe0
[ 1782.470015]  ? poll_initwait+0x90/0x90
[ 1782.470017]  ? poll_freewait+0x110/0x110
[ 1782.470020]  ? _raw_spin_trylock_bh+0x100/0x100
[ 1782.470022]  ? rb_insert_color+0x32/0x350
[ 1782.470024]  ? kmem_cache_alloc+0x1a3/0x280
[ 1782.470026]  ? __kasan_check_write+0x14/0x20
[ 1782.470029]  ? apparmor_file_alloc_security+0x165/0x390
[ 1782.470031]  ? apparmor_ptrace_access_check+0x300/0x300
[ 1782.470034]  ? kmemleak_alloc+0x4b/0x80
[ 1782.470036]  ? memcg_kmem_put_cache+0x1b/0x90
[ 1782.470038]  ? kmem_cache_alloc+0x1a3/0x280
[ 1782.470041]  ? __kasan_check_write+0x14/0x20
[ 1782.470042]  ? __mutex_init+0x6e/0x80
[ 1782.470046]  ? percpu_counter_add_batch+0x25/0xb0
[ 1782.470048]  ? __alloc_file+0x16e/0x1c0
[ 1782.470050]  ? alloc_empty_file+0x74/0xd0
[ 1782.470053]  ? errseq_sample+0xd/0x20
[ 1782.470055]  ? alloc_file+0x1a2/0x230
[ 1782.470057]  ? alloc_file_pseudo+0x160/0x1f0
[ 1782.470059]  ? alloc_file+0x230/0x230
[ 1782.470062]  ? __alloc_fd+0x111/0x290
[ 1782.470065]  __x64_sys_poll+0x99/0x230
[ 1782.470068]  ? __ia32_compat_sys_ppoll_time64+0x1a0/0x1a0
[ 1782.470071]  do_syscall_64+0x52/0xc0
[ 1782.470074]  entry_SYSCALL_64_after_hwframe+0x44/0xa9
[ 1782.470076] RIP: 0033:0x7f467e89faff
[ 1782.470079] Code: 54 24 1c 48 89 74 24 10 48 89 7c 24 08 e8 79 1c f8 ff 8b 54 24 1c 48 8b 74 24 10 41 89 c0 48 8b 7c 24 08 b8 07 00 00 00 0f 05 <48> 3d 00 f0 ff ff 77 2b 44 89 c7 89 44 24 08 e8 ad 1c f8 ff 8b 44
[ 1782.470080] RSP: 002b:00007f465c8f5a90 EFLAGS: 00000297 ORIG_RAX: 0000000000000007
[ 1782.470083] RAX: ffffffffffffffda RBX: 00007f4664000c20 RCX: 00007f467e89faff
[ 1782.470084] RDX: 00000000ffffffff RSI: 0000000000000002 RDI: 00007f465c8f5b90
[ 1782.470085] RBP: 0000000000000001 R08: 0000000000000001 R09: 0000000000000001
[ 1782.470086] R10: 0000000000000001 R11: 0000000000000297 R12: 0000000000000001
[ 1782.470088] R13: 0000000000000001 R14: 0000000001000000 R15: 00007f4656fff010

[ 1782.470092] Allocated by task 8923:
[ 1782.470095]  save_stack+0x23/0x50
[ 1782.470097]  __kasan_kmalloc.constprop.0+0xcf/0xe0
[ 1782.470098]  kasan_kmalloc+0x9/0x10
[ 1782.470100]  __kmalloc+0x146/0x2f0
[ 1782.470105]  __vb2_queue_alloc+0xae/0x660 [videobuf2_common]
[ 1782.470111]  vb2_core_reqbufs+0x45a/0x690 [videobuf2_common]
[ 1782.470116]  __vb2_init_fileio+0x189/0x470 [videobuf2_common]
[ 1782.470121]  vb2_core_poll+0x260/0x320 [videobuf2_common]
[ 1782.470126]  vb2_poll+0x34/0xd0 [videobuf2_v4l2]
[ 1782.470130]  vb2_fop_poll+0x9f/0x1b0 [videobuf2_v4l2]
[ 1782.470149]  v4l2_poll+0xf2/0x110 [videodev]
[ 1782.470151]  do_sys_poll+0x454/0x780
[ 1782.470153]  __x64_sys_poll+0x99/0x230
[ 1782.470155]  do_syscall_64+0x52/0xc0
[ 1782.470157]  entry_SYSCALL_64_after_hwframe+0x44/0xa9

[ 1782.470159] Freed by task 8791:
[ 1782.470161]  save_stack+0x23/0x50
[ 1782.470163]  __kasan_slab_free+0x137/0x180
[ 1782.470164]  kasan_slab_free+0xe/0x10
[ 1782.470166]  kfree+0xa8/0x280
[ 1782.470168]  load_elf_binary+0x13a2/0x244f
[ 1782.470171]  __do_execve_file.isra.0+0x9e6/0x11f0
[ 1782.470173]  __x64_sys_execve+0x59/0x70
[ 1782.470175]  do_syscall_64+0x52/0xc0
[ 1782.470177]  entry_SYSCALL_64_after_hwframe+0x44/0xa9

[ 1782.470180] The buggy address belongs to the object at ffff88814e99a000
                which belongs to the cache kmalloc-1k of size 1024
[ 1782.470183] The buggy address is located 540 bytes inside of
                1024-byte region [ffff88814e99a000, ffff88814e99a400)
[ 1782.470184] The buggy address belongs to the page:
[ 1782.470189] page:ffffea00053a6600 refcount:1 mapcount:0 mapping:0000000000000000 index:0x0 head:ffffea00053a6600 order:3 compound_mapcount:0 compound_pincount:0
[ 1782.470192] flags: 0x17ffffc0010200(slab|head)
[ 1782.470196] raw: 0017ffffc0010200 ffffea00051f7000 0000000200000002 ffff8881c8c0ea00
[ 1782.470199] raw: 0000000000000000 0000000080100010 00000001ffffffff 0000000000000000
[ 1782.470199] page dumped because: kasan: bad access detected

[ 1782.470201] Memory state around the buggy address:
[ 1782.470204]  ffff88814e99a100: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
[ 1782.470206]  ffff88814e99a180: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
[ 1782.470209] >ffff88814e99a200: 00 00 00 fc fc fc fc fc fc fc fc fc fc fc fc fc
[ 1782.470210]                             ^
[ 1782.470212]  ffff88814e99a280: fc fc fc fc fc fc fc fc fc fc fc fc fc fc fc fc
[ 1782.470215]  ffff88814e99a300: fc fc fc fc fc fc fc fc fc fc fc fc fc fc fc fc
[ 1782.470216] ==================================================================
```