### PR TITLE
Fix vcam stuck in the v4l2-compliance test

### DIFF
--- a/device.c
+++ b/device.c
@@ -299,7 +299,7 @@ static int vcam_enum_frameintervals(struct file *file,
     frm_step->min.numerator = 1001;
     frm_step->min.denominator = 60000;
     frm_step->max.numerator = 1001;
-    frm_step->max.denominator = 1;
+    frm_step->max.denominator = 1001;
     frm_step->step.numerator = 1001;
     frm_step->step.denominator = 60000;
 


### PR DESCRIPTION
This problem is that an infinite loop happendes
when Hz is smaller than one. I change the denominator
to solve this problem.

To check the result, use the following command:
$sudo v4l2-compliance -d /dev/videoX -f
```
Stream using all formats:
	test MMAP for Format RGB3, Frame Size 640x480@60.00 Hz:
		                                                            		Stride 1920, Field None: OK
	test MMAP for Format RGB3, Frame Size 640x480@1.00 Hz:
		                                                            		Stride 1920, Field None: OK
```