### PR TITLE
Fix the warnings in Sparse

### DIFF
--- a/control.c
+++ b/control.c
@@ -44,7 +44,7 @@ static ssize_t control_read(struct file *file,
 {
     int len;
     static const char *str = "Virtual V4L2 compatible camera device\n";
-    pr_debug("read %ld %dB\n", (long) buffer, (int) length);
+    pr_debug("read %ld %dB\n", (long __force) buffer, (int) length);
     len = strlen(str);
     if (len < length)
         len = length;
@@ -58,7 +58,7 @@ static ssize_t control_write(struct file *file,
                              size_t length,
                              loff_t *offset)
 {
-    pr_debug("write %ld %dB\n", (long) buffer, (int) length);
+    pr_debug("write %ld %dB\n", (long __force) buffer, (int) length);
     return length;
 }
 

--- a/control.c
+++ b/control.c
@@ -44,7 +44,7 @@ static ssize_t control_read(struct file *file,
 {
     int len;
     static const char *str = "Virtual V4L2 compatible camera device\n";
-    pr_debug("read %ld %dB\n", (long __force) buffer, (int) length);
+    pr_debug("read %p %dB\n", buffer, (int) length);
     len = strlen(str);
     if (len < length)
         len = length;
@@ -58,7 +58,7 @@ static ssize_t control_write(struct file *file,
                              size_t length,
                              loff_t *offset)
 {
-    pr_debug("write %ld %dB\n", (long __force) buffer, (int) length);
+    pr_debug("write %p %dB\n", buffer, (int) length);
     return length;
 }
 

--- a/fb.c
+++ b/fb.c
@@ -98,7 +98,7 @@ static ssize_t vcamfb_write(struct file *file,
         return 0;
     }
 
-    if (copy_from_user(data + buf->filled, (void *) buffer, to_be_copyied) !=
+    if (copy_from_user(data + buf->filled, (void __user *) buffer, to_be_copyied) !=
         0) {
         pr_warn("Failed to copy_from_user!");
     }
@@ -224,7 +224,7 @@ static ssize_t vcam_fb_write(struct fb_info *info,
         return 0;
     }
 
-    if (copy_from_user(data + buf->filled, (void *) buffer, to_be_copyied) !=
+    if (copy_from_user(data + buf->filled, (void __user *) buffer, to_be_copyied) !=
         0) {
         pr_warn("Failed to copy_from_user!");
     }


### PR DESCRIPTION
Following issue#16, this patch Adds
`__user` casts and `__force` casts for fixing
this problem.