### PR TITLE
Add missing include for vmalloc

### DIFF
--- a/fb.c
+++ b/fb.c
@@ -4,6 +4,7 @@
 #include <linux/kernel.h>
 #include <linux/spinlock.h>
 #include <linux/version.h>
+#include <linux/vmalloc.h>
 
 #include "fb.h"
 


### PR DESCRIPTION
Include <linux/vmalloc.h> to fix implicit declaration warnings.