### PR TITLE
Fix typos in log messages

### DIFF
--- a/control.c
+++ b/control.c
@@ -142,7 +142,7 @@ static long control_ioctl(struct file *file,
     }
     switch (iocontrol_cmd) {
     case VCAM_IOCTL_CREATE_DEVICE:
-        pr_debug("Requesing new device\n");
+        pr_debug("Requesting new device\n");
         ret = request_vcam_device(&dev_spec);
         break;
     case VCAM_IOCTL_DESTROY_DEVICE:

--- a/fb.c
+++ b/fb.c
@@ -21,7 +21,7 @@ static int vcam_fb_open(struct fb_info *info, int user)
 
     struct vcam_device *dev = info->par;
     if (!dev) {
-        pr_err("Private data field of PDE not initilized.\n");
+        pr_err("Private data field of PDE not initialized.\n");
         return -ENODEV;
     }
 
@@ -85,7 +85,7 @@ static ssize_t vcam_fb_write(struct fb_info *info,
     /* Reset buffer if last write is too old */
     if ((buf->xbar || buf->ybar || buf->filled) &&
         (((int32_t) jiffies - buf->jiffies) / HZ)) {
-        pr_debug("Reseting jiffies, difference %d\n",
+        pr_debug("Resetting jiffies, difference %d\n",
                  ((int32_t) jiffies - buf->jiffies));
         buf->filled = 0;
         buf->xbar = 0;


### PR DESCRIPTION
  - initilized -> initialized (fb.c)
  - Reseting -> Resetting (fb.c)
  - Requesing -> Requesting (control.c)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed spelling in kernel log messages in fb.c and control.c to improve clarity and make log searches consistent (initilized→initialized, Reseting→Resetting, Requesing→Requesting).

<sup>Written for commit 7c4210b3843b3028fd61e1421c3f82e535c51fa2. Summary will update on new commits. <a href="https://cubic.dev/pr/sysprog21/vcam/pull/43?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

