### PR TITLE
Fix vcam_enum_framesizes to enumerate all sizes when scaling is enabled

### DIFF
--- a/device.c
+++ b/device.c
@@ -306,25 +306,14 @@ static int vcam_enum_framesizes(struct file *file,
         size_discrete = &fsize->discrete;
         size_discrete->width = dev->output_format.width;
         size_discrete->height = dev->output_format.height;
-    } else if (dev->conv_res_on) {
-        if (fsize->index > 0)
+    } else {
+        if (fsize->index >= ARRAY_SIZE(vcam_sizes))
             return -EINVAL;
 
         fsize->type = V4L2_FRMSIZE_TYPE_DISCRETE;
         size_discrete = &fsize->discrete;
-        size_discrete->width = dev->output_format.width;
-        size_discrete->height = dev->output_format.height;
-    } else {
-        if (fsize->index > 0)
-            return -EINVAL;
-
-        fsize->type = V4L2_FRMSIZE_TYPE_STEPWISE;
-        fsize->stepwise.min_width = 64;
-        fsize->stepwise.max_width = 1280;
-        fsize->stepwise.step_width = 2;
-        fsize->stepwise.min_height = 64;
-        fsize->stepwise.max_height = 720;
-        fsize->stepwise.step_height = 2;
+        size_discrete->width = vcam_sizes[fsize->index].width;
+        size_discrete->height = vcam_sizes[fsize->index].height;
     }
 
     return 0;


### PR DESCRIPTION
  When scaling is enabled, `vcam_enum_framesizes` only returned one frame size because the index guard was never updated after the branch was changed. The original else block also became unreachable dead code.

  Fix by removing the dead code and enumerating `vcam_sizes[]` by index.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes vcam_enum_framesizes to return all discrete frame sizes instead of only the current output size when scaling is enabled. Removes redundant branches and adds proper bounds checking.

- **Bug Fixes**
  - Iterates `vcam_sizes[fsize->index]` with `>= ARRAY_SIZE(vcam_sizes)` guard to enumerate all discrete sizes.
  - Removes the `conv_res_on` duplicate path and the unreachable stepwise branch.

<sup>Written for commit ca444a020d89b6899d5b210e8a45fc3b931d0fc6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysprog21/vcam/pull/44?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

