### PR TITLE
Fix read length handling

### DIFF
--- a/control.c
+++ b/control.c
@@ -42,15 +42,9 @@ static ssize_t control_read(struct file *file,
                             size_t length,
                             loff_t *offset)
 {
-    int len;
     static const char *str = "Virtual V4L2 compatible camera device\n";
     pr_debug("read %p %dB\n", buffer, (int) length);
-    len = strlen(str);
-    if (len < length)
-        len = length;
-    if (copy_to_user(buffer, str, len) != 0)
-        pr_warn("Failed to copy_to_user!");
-    return len;
+    return simple_read_from_buffer(buffer, length, offset, str, strlen(str));
 }
 
 static ssize_t control_write(struct file *file,


### PR DESCRIPTION
Function `control_read()` uses `strlen(str)` as the source length, but replaces it with the user supplied length when the user buffer is larger. This makes `copy_to_user()` read past the end of the static string.

The callback also ignores the file offset, so repeated reads do not reach **EOF** as expected.

Use `simple_read_from_buffer()` to limit the copy to the requested count and update the offset consistently.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix control_read to cap read length and honor file offsets by using simple_read_from_buffer, preventing reads past the static string and making repeated reads reach EOF.

<sup>Written for commit 7bf0aba3c220104baf837bb707ae77a4cccff3ae. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysprog21/vcam/pull/45?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

