### PR TITLE
Fix device removal locking

### DIFF
--- a/control.c
+++ b/control.c
@@ -102,27 +102,31 @@ static int control_iocontrol_modify_input_setting(
 static int control_iocontrol_destroy_device(struct vcam_device_spec *dev_spec)
 {
     struct vcam_device *dev;
-    unsigned long flags = 0;
+    unsigned long ctldev_flags = 0;
+    unsigned long dev_flags = 0;
     int i;
 
-    if (ctldev->vcam_device_count <= dev_spec->idx)
+    spin_lock_irqsave(&ctldev->vcam_devices_lock, ctldev_flags);
+    if (ctldev->vcam_device_count <= dev_spec->idx) {
+        spin_unlock_irqrestore(&ctldev->vcam_devices_lock, ctldev_flags);
         return -EINVAL;
+    }
 
     dev = ctldev->vcam_devices[dev_spec->idx];
 
-    spin_lock_irqsave(&dev->in_fh_slock, flags);
+    spin_lock_irqsave(&dev->in_fh_slock, dev_flags);
     if (dev->fb_isopen || vb2_is_busy(&dev->vb_out_vidq)) {
-        spin_unlock_irqrestore(&dev->in_fh_slock, flags);
+        spin_unlock_irqrestore(&dev->in_fh_slock, dev_flags);
+        spin_unlock_irqrestore(&ctldev->vcam_devices_lock, ctldev_flags);
         return -EBUSY;
     }
     dev->fb_isopen = true;
-    spin_unlock_irqrestore(&dev->in_fh_slock, flags);
+    spin_unlock_irqrestore(&dev->in_fh_slock, dev_flags);
 
-    spin_lock_irqsave(&ctldev->vcam_devices_lock, flags);
-    for (i = dev_spec->idx; i < (ctldev->vcam_device_count); i++)
+    for (i = dev_spec->idx; i + 1 < (ctldev->vcam_device_count); i++)
         ctldev->vcam_devices[i] = ctldev->vcam_devices[i + 1];
     ctldev->vcam_devices[--ctldev->vcam_device_count] = NULL;
-    spin_unlock_irqrestore(&ctldev->vcam_devices_lock, flags);
+    spin_unlock_irqrestore(&ctldev->vcam_devices_lock, ctldev_flags);
 
     destroy_vcam_device(dev);
 


### PR DESCRIPTION
`control_iocontrol_destroy_device()` reads a `vcam_devices` entry before
taking `vcam_devices_lock`, but later removes entries from the same
array while holding the lock. Concurrent destroy requests can therefore
use a stale index or device pointer after another request shifts the
array.

Take `vcam_devices_lock` before validating the index and reading the
device pointer. Remove the device from `vcam_devices` while still
holding the lock, then release the lock before destroying the device.

Also stop the removal loop before i + 1 reaches `vcam_device_count`, so it
does not read past the last valid `vcam_devices` entry.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix race and off-by-one in device removal to prevent stale pointers and out-of-bounds access. Take `vcam_devices_lock` before validating the index and reading the device pointer, shift `vcam_devices` with `i + 1 < vcam_device_count`, then release the lock before destroying the device.

<sup>Written for commit f0fc97cfc4292b4e5d5998805c17707b73b05289. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysprog21/vcam/pull/46?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->





