### PR TITLE
Fix vcam_device type in memset

### DIFF
--- a/control.c
+++ b/control.c
@@ -217,8 +217,7 @@ static struct control_device *alloc_control_device(void)
         sizeof(struct vcam_device *) * devices_max, GFP_KERNEL);
     if (!(res->vcam_devices))
         goto vcam_alloc_failure;
-    memset(res->vcam_devices, 0x00,
-           sizeof(struct vcam_devices *) * devices_max);
+    memset(res->vcam_devices, 0x00, sizeof(struct vcam_device *) * devices_max);
     res->vcam_device_count = 0;
 
     return res;


### PR DESCRIPTION
Pointer `vcam_devices` stores struct `vcam_device` pointers. The allocation uses `sizeof(struct vcam_device *)`, but the following `memset` uses the pluralized struct `vcam_devices` tag.

This does not change the cleared size because the expression is still a pointer type. However, using the actual element type keeps the code consistent with the field declaration and allocation.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use the correct `struct vcam_device *` type in `memset` for `vcam_devices`, matching the allocation and field declaration. The previous pluralized tag (`struct vcam_devices *`) didn’t affect size, but this keeps the initialization consistent.

<sup>Written for commit 4aa7c77c382c25b8ed6a279f9f59e7c5ddb9cfb4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysprog21/vcam/pull/47?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



