### PR TITLE
Fix vcam streaming lifecycle correctness in videobuf

### DIFF
--- a/videobuf.c
+++ b/videobuf.c
@@ -70,8 +70,9 @@ static int vcam_start_streaming(struct vb2_queue *q, unsigned int count)
 
     /* Try to start kernel thread */
     dev->sub_thr_id = kthread_create(submitter_thread, dev, "vcam_submitter");
-    if (!dev->sub_thr_id) {
+    if (IS_ERR(dev->sub_thr_id)) {
         pr_err("Failed to create kernel thread\n");
+        dev->sub_thr_id = NULL;
         return -ECANCELED;
     }
 

--- a/videobuf.c
+++ b/videobuf.c
@@ -86,22 +86,25 @@ static void vcam_stop_streaming(struct vb2_queue *vb2_q)
     struct vcam_device *dev = vb2_q->drv_priv;
     struct vcam_out_queue *q = &dev->vcam_out_vidq;
     unsigned long flags = 0;
+    LIST_HEAD(tmp_list);
 
-    /* Stop running threads */
     if (dev->sub_thr_id)
         kthread_stop(dev->sub_thr_id);
-
     dev->sub_thr_id = NULL;
-    /* Empty buffer queue */
+
+    /* Collect buffers under spinlock, return them to vb2 outside it.
+     * vb2_buffer_done() must not be called while holding a spinlock. */
     spin_lock_irqsave(&dev->out_q_slock, flags);
-    while (!list_empty(&q->active)) {
+    list_splice_init(&q->active, &tmp_list);
+    spin_unlock_irqrestore(&dev->out_q_slock, flags);
+
+    while (!list_empty(&tmp_list)) {
         struct vcam_out_buffer *buf =
-            list_entry(q->active.next, struct vcam_out_buffer, list);
+            list_entry(tmp_list.next, struct vcam_out_buffer, list);
         list_del(&buf->list);
         vb2_buffer_done(&buf->vb.vb2_buf, VB2_BUF_STATE_ERROR);
         pr_debug("Throwing out buffer\n");
     }
-    spin_unlock_irqrestore(&dev->out_q_slock, flags);
 }
 
 static void vcam_outbuf_lock(struct vb2_queue *vq)


### PR DESCRIPTION
  Two correctness fixes in `videobuf.c` for the streaming lifecycle:

  - `vcam_start_streaming()`: `kthread_create()` returns `ERR_PTR(-ENOMEM)`
    on failure, not `NULL`. The previous `!ptr` check evaluates to `false`
    for any `ERR_PTR` value since it is a non-zero pointer, leaving
    `sub_thr_id` holding an invalid address. Replace with `IS_ERR()` and
    reset `sub_thr_id` to `NULL` on failure so `vcam_stop_streaming()`
    skips the `kthread_stop()` call safely.

  - `vcam_stop_streaming()`: `vb2_buffer_done()` must not be called in
    atomic context as it internally invokes `wake_up()` on the done wait
    queue. Use `list_splice_init()` to transfer all active buffers to a
    temporary local list in O(1) while holding the spinlock, then release
    the lock before iterating and calling `vb2_buffer_done()`. This also
    minimises the critical section length.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes vcam streaming lifecycle issues in `videobuf.c` to avoid crashes and stuck buffers. Improves correctness when starting and stopping streaming.

- **Bug Fixes**
  - Use `IS_ERR()` for `kthread_create()` and reset `sub_thr_id` to `NULL` on failure so `vcam_stop_streaming()` safely skips `kthread_stop()`.
  - Move `vb2_buffer_done()` out of the spinlock: `list_splice_init()` active buffers to a temp list under lock, then complete them unlocked with `VB2_BUF_STATE_ERROR`.

<sup>Written for commit 10ead390a4fc1ee98bc44453e71558733d60104a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysprog21/vcam/pull/48?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

