### PR TITLE
Fix capture frame interval handling

### DIFF
--- a/device.c
+++ b/device.c
@@ -49,6 +49,10 @@ static const struct v4l2_frmsize_discrete vcam_sizes[] = {
     {HD_720_WIDTH, HD_720_HEIGHT},
 };
 
+static const struct v4l2_fract vcam_frame_interval_min = {1001, 60000};
+static const struct v4l2_fract vcam_frame_interval_max = {1001, 1001};
+static const struct v4l2_fract vcam_frame_interval_default = {1001, 30000};
+
 static int vcam_querycap(struct file *file,
                          void *priv,
                          struct v4l2_capability *cap)
@@ -230,12 +234,9 @@ static int vcam_enum_frameintervals(struct file *file,
 
     fival->type = V4L2_FRMIVAL_TYPE_STEPWISE;
     frm_step = &fival->stepwise;
-    frm_step->min.numerator = 1001;
-    frm_step->min.denominator = 60000;
-    frm_step->max.numerator = 1001;
-    frm_step->max.denominator = 1001;
-    frm_step->step.numerator = 1001;
-    frm_step->step.denominator = 60000;
+    frm_step->min = vcam_frame_interval_min;
+    frm_step->max = vcam_frame_interval_max;
+    frm_step->step = vcam_frame_interval_min;
 
     return 0;
 }
@@ -255,11 +256,28 @@ static int vcam_g_parm(struct file *file,
 
     memset(cp, 0x00, sizeof(struct v4l2_captureparm));
     cp->capability = V4L2_CAP_TIMEPERFRAME;
-    cp->timeperframe = dev->output_fps;
+    cp->timeperframe = dev->frame_interval;
     cp->extendedmode = 0;
     cp->readbuffers = 1;
 
     return 0;
+}
+
+static void clamp_frame_interval(struct v4l2_fract *interval)
+{
+    u64 value = (u64) interval->numerator *
+                vcam_frame_interval_min.denominator;
+    u64 min = (u64) vcam_frame_interval_min.numerator *
+              interval->denominator;
+    u64 max_value = (u64) interval->numerator *
+                    vcam_frame_interval_max.denominator;
+    u64 max = (u64) vcam_frame_interval_max.numerator *
+              interval->denominator;
+
+    if (value < min)
+        *interval = vcam_frame_interval_min;
+    else if (max_value > max)
+        *interval = vcam_frame_interval_max;
 }
 
 static int vcam_s_parm(struct file *file,
@@ -277,14 +295,16 @@ static int vcam_s_parm(struct file *file,
 
     cp->capability = V4L2_CAP_TIMEPERFRAME;
     if (!cp->timeperframe.numerator || !cp->timeperframe.denominator)
-        cp->timeperframe = dev->output_fps;
-    else
-        dev->output_fps = cp->timeperframe;
+        cp->timeperframe = dev->frame_interval;
+    else {
+        clamp_frame_interval(&cp->timeperframe);
+        dev->frame_interval = cp->timeperframe;
+    }
     cp->extendedmode = 0;
     cp->readbuffers = 1;
 
-    pr_debug("FPS set to %d/%d\n", cp->timeperframe.numerator,
-             cp->timeperframe.denominator);
+    pr_debug("Frame interval set to %d/%d\n",
+             cp->timeperframe.numerator, cp->timeperframe.denominator);
     return 0;
 }
 
@@ -661,10 +681,9 @@ int submitter_thread(void *data)
 
     while (!kthread_should_stop()) {
         struct vcam_out_buffer *buf;
-        int timeout_ms, timeout;
-
-        /* Do something and sleep */
-        int computation_time_jiff = jiffies;
+        unsigned long frame_interval;
+        unsigned long processing_start = jiffies;
+        unsigned long processing_time;
         spin_lock_irqsave(&dev->out_q_slock, flags);
         if (list_empty(&q->active)) {
             pr_debug("Buffer queue is empty\n");
@@ -691,28 +710,17 @@ int submitter_thread(void *data)
         }
 
     have_a_nap:
-        if (!dev->output_fps.denominator) {
-            dev->output_fps.numerator = 1001;
-            dev->output_fps.denominator = 30000;
-        }
-        timeout_ms = dev->output_fps.denominator / dev->output_fps.numerator;
-        if (!timeout_ms) {
-            dev->output_fps.numerator = 1001;
-            dev->output_fps.denominator = 60000;
-            timeout_ms =
-                dev->output_fps.denominator / dev->output_fps.numerator;
-        }
+        if (!dev->frame_interval.denominator)
+            dev->frame_interval = vcam_frame_interval_default;
 
-        /* Compute timeout and update FPS */
-        computation_time_jiff = jiffies - computation_time_jiff;
-        timeout = msecs_to_jiffies(timeout_ms);
-        if (computation_time_jiff > timeout) {
-            int computation_time_ms = msecs_to_jiffies(computation_time_jiff);
-            dev->output_fps.numerator = 1001;
-            dev->output_fps.denominator = 1000 * computation_time_ms;
-        } else if (timeout > computation_time_jiff) {
-            schedule_timeout_interruptible(timeout - computation_time_jiff);
-        }
+        frame_interval = max_t(
+            unsigned long, 1,
+            DIV_ROUND_CLOSEST_ULL(
+                (u64) dev->frame_interval.numerator * HZ,
+                dev->frame_interval.denominator));
+        processing_time = jiffies - processing_start;
+        if (frame_interval > processing_time)
+            schedule_timeout_interruptible(frame_interval - processing_time);
     }
 
     return 0;
@@ -856,8 +864,7 @@ struct vcam_device *create_vcam_device(size_t idx,
     }
     vcam->fb_isopen = 0;
 
-    vcam->output_fps.numerator = 1001;
-    vcam->output_fps.denominator = 30000;
+    vcam->frame_interval = vcam_frame_interval_default;
 
     return vcam;
 

--- a/device.h
+++ b/device.h
@@ -67,8 +67,8 @@ struct vcam_device {
     struct vb2_queue vb_out_vidq;
     struct vcam_out_queue vcam_out_vidq;
     spinlock_t out_q_slock;
-    /* Output framerate */
-    struct v4l2_fract output_fps;
+    /* Output frame interval */
+    struct v4l2_fract frame_interval;
 
     /* Input framebuffer */
     char vcam_fb_fname[FB_NAME_MAXLENGTH];


### PR DESCRIPTION
## Summary

Fix the mismatch between the frame interval reported through
`VIDIOC_G_PARM` and the actual capture timing.

The previous implementation calculated:

```
denominator / numerator
```
For the default 1001/30000 time-per-frame value, this produces about
29.97, which represents frames per second, but was treated as milliseconds.

The new implementation calculates:
```
frame interval in jiffies = numerator * HZ / denominator
```
  It then subtracts the frame processing time before sleeping, so the actual
  capture period follows the configured V4L2 time-per-frame value.

  Other changes:

  - Rename `output_fps` to `frame_interval` because it stores seconds per
    frame, not frames per second.

  - Clamp `VIDIOC_S_PARM` values to the range advertised by
    `VIDIOC_ENUM_FRAMEINTERVALS`.

  - Reuse the same interval definitions for enumeration, initialization,
    setting, reporting, and frame pacing.

  ## Test results

  Before:

  Frame interval: reported=33.367 ms measured=29.989 ms
  error=10.1% [FAIL]

  After:

  Frame interval: reported=33.367 ms measured=33.997 ms
  error=1.9% [PASS]

  Additional tests:

  25 FPS: reported=40.000 ms measured=41.008 ms error=2.5% [PASS]
  YUYV: reported=33.367 ms measured=34.012 ms error=1.9% [PASS]


  Fixes #49


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes incorrect frame pacing by computing and applying the V4L2 time-per-frame correctly. Reported and actual intervals now align, reducing timing error from ~10% to ~2%.

- **Bug Fixes**
  - Compute frame interval in jiffies: numerator * HZ / denominator.
  - Subtract processing time before sleeping to keep the configured period.
  - Rename `output_fps` to `frame_interval` (seconds per frame).
  - Clamp `VIDIOC_S_PARM` to the range from `VIDIOC_ENUM_FRAMEINTERVALS`.
  - Define shared min/max/default intervals and reuse them for enum/init/get/set/pacing.

<sup>Written for commit ef4fd9ee3899a2dfeb5de3d43e22d12312c3ef1f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysprog21/vcam/pull/50?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

