### PR TITLE
Add automated V4L2 test workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ Module.symvers
 Mkfile.old
 dkms.conf
 vcam-util
+
+# Test artifacts
+artifacts/

--- a/Makefile
+++ b/Makefile
@@ -17,3 +17,7 @@ kmod:
 clean:
 	$(MAKE) -C /lib/modules/$(shell uname -r)/build M=$(PWD) clean
 	$(RM) vcam-util
+
+.PHONY: test-v4l2
+test-v4l2:
+	./scripts/test-v4l2.sh

--- a/scripts/test-v4l2.sh
+++ b/scripts/test-v4l2.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+ARTIFACT_DIR="${ROOT_DIR}/artifacts/v4l2-$(date +%Y%m%d-%H%M%S)"
+LOG="${ARTIFACT_DIR}/test.log"
+
+mkdir -p "${ARTIFACT_DIR}"
+exec > >(tee -a "${LOG}") 2>&1
+
+cd "${ROOT_DIR}"
+
+echo "== Environment =="
+uname -a
+echo
+
+echo "== Build =="
+make clean
+make
+echo
+
+echo "== Load dependencies =="
+sudo modprobe -a videobuf2_vmalloc videobuf2_v4l2 videobuf2_dma_contig
+echo
+
+echo "== Reload vcam =="
+sudo rmmod vcam 2>/dev/null || true
+sudo insmod vcam.ko
+echo
+
+echo "== Detect video device =="
+sudo ./vcam-util -l | tee "${ARTIFACT_DIR}/vcam-util-list.txt"
+VIDEO_DEV="$(sudo ./vcam-util -l |
+    awk '/\/dev\/video[0-9]+/ {print $NF; exit}')"
+
+if [[ -z "${VIDEO_DEV}" ]]; then
+    echo "ERROR: cannot find a vcam video device"
+    exit 1
+fi
+
+echo "VIDEO_DEV=${VIDEO_DEV}" | tee "${ARTIFACT_DIR}/device.env"
+echo
+
+echo "== v4l2-compliance =="
+sudo v4l2-compliance -d "${VIDEO_DEV}" -f |
+    tee "${ARTIFACT_DIR}/v4l2-compliance.txt"
+echo
+
+echo "== v4l2-ctl --all =="
+sudo v4l2-ctl -d "${VIDEO_DEV}" --all |
+    tee "${ARTIFACT_DIR}/v4l2-ctl-all.txt"
+echo
+
+echo "== v4l2-ctl --list-formats-ext =="
+sudo v4l2-ctl -d "${VIDEO_DEV}" --list-formats-ext |
+    tee "${ARTIFACT_DIR}/v4l2-formats-ext.txt"
+echo
+
+echo "== dmesg tail =="
+sudo dmesg | tail -n 100 |
+    tee "${ARTIFACT_DIR}/dmesg-tail.txt" || true
+echo
+
+echo "Artifacts saved to: ${ARTIFACT_DIR}"

--- a/scripts/test-v4l2.sh
+++ b/scripts/test-v4l2.sh
@@ -30,9 +30,13 @@ sudo insmod vcam.ko
 echo
 
 echo "== Detect video device =="
-sudo ./vcam-util -l | tee "${ARTIFACT_DIR}/vcam-util-list.txt"
-VIDEO_DEV="$(sudo ./vcam-util -l |
-    awk '/\/dev\/video[0-9]+/ {print $NF; exit}')"
+VCAM_LIST="$(sudo ./vcam-util -l)"
+printf '%s\n' "${VCAM_LIST}" | tee "${ARTIFACT_DIR}/vcam-util-list.txt"
+VIDEO_DEV="$(printf '%s\n' "${VCAM_LIST}" |
+    awk 'match($0, /\/dev\/video[0-9]+/) {
+        print substr($0, RSTART, RLENGTH)
+        exit
+    }')"
 
 if [[ -z "${VIDEO_DEV}" ]]; then
     echo "ERROR: cannot find a vcam video device"


### PR DESCRIPTION
  ## Summary

  Add a `make test-v4l2` target for repeatable local V4L2 validation.

  The test workflow:

  - Builds the kernel module and `vcam-util`.
  - Loads the required videobuf2 modules.
  - Reloads `vcam.ko`.
  - Detects the created `/dev/videoX` device.
  - Runs `v4l2-compliance -f`.
  - Runs `v4l2-ctl --all`.
  - Runs `v4l2-ctl --list-formats-ext`.
  - Saves the output and recent `dmesg` messages in a timestamped artifact
    directory.

  Artifacts are stored under:

  ```text
  artifacts/v4l2-YYYYMMDD-HHMMSS/
```
  The artifact directory is excluded through .gitignore. With pipefail
  enabled, failures from the main validation commands cause the test target
  to fail instead of being hidden by tee.

  ## Usage

  make test-v4l2

  The workflow requires v4l-utils, kernel module build dependencies, and
  permission to run the required commands through sudo.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `make test-v4l2` to run a repeatable local V4L2 validation and save logs as artifacts. This helps catch driver issues and makes results easy to share.

- **New Features**
  - `make test-v4l2` runs `scripts/test-v4l2.sh` to build, load `videobuf2_*`, reload `vcam.ko`, and run `v4l2-compliance` and `v4l2-ctl` on the created device.
  - Saves outputs and a `dmesg` tail to `artifacts/v4l2-YYYYMMDD-HHMMSS/` (ignored). Fails on validation errors. Usage: `make test-v4l2` (needs `v4l-utils`, build deps, and `sudo`).

- **Bug Fixes**
  - More robust device detection: parse `vcam-util -l` to find `/dev/videoX`, persist to `device.env`, and fail if not found.

<sup>Written for commit d30c6cbad52767caf6da53198079aea9eefbc56b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysprog21/vcam/pull/51?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

