### PR TITLE
reject format changes while buffers are allocated

### DIFF
--- a/device.c
+++ b/device.c
@@ -187,6 +187,9 @@ static int vcam_s_fmt_vid_cap(struct file *file,
 
     struct vcam_device *dev = (struct vcam_device *) video_drvdata(file);
 
+    if (vb2_is_busy(&dev->vb_out_vidq))
+        return -EBUSY;
+
     ret = vcam_try_fmt_vid_cap(file, priv, f);
     if (ret < 0)
         return ret;


### PR DESCRIPTION
## Summary

  Reject `VIDIOC_S_FMT` with `EBUSY` while videobuf2 buffers are allocated.

  Previously, `VIDIOC_S_FMT` updated `dev->output_format` even when existing
  buffers had been allocated using the previous format's `sizeimage`. This
  could leave the current format and buffer sizes inconsistent, causing a
  later `VIDIOC_QBUF` call to fail.

  The change checks `vb2_is_busy()` before applying the new format. Applications
  must release existing buffers with `VIDIOC_REQBUFS count=0` before changing
  the format.

  ## Test results

  Before:

  ```text
  Initial format: 640x480 YUYV, bytesperline=1280, sizeimage=614400
  Allocated buffers: 3
  Buffer 0 length: 614400
  S_FMT after REQBUFS: succeeded
  Current format: 640x480 RGB3, bytesperline=1920, sizeimage=921600
  QBUF after S_FMT: failed: Invalid argument
```
  After:
```
 Initial format: 640x480 YUYV, bytesperline=1280, sizeimage=614400
 Allocated buffers: 3
 Buffer 0 length: 614400
 S_FMT after REQBUFS: failed: Device or resource busy
 Current format: 640x480 YUYV, bytesperline=1280, sizeimage=614400
 QBUF after S_FMT: succeeded
```
  V4L2 compliance:

  Total: 50, Succeeded: 50, Failed: 0, Warnings: 0

  Fixes #52


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reject `VIDIOC_S_FMT` while videobuf2 buffers are allocated, returning `-EBUSY`. This keeps the current format consistent with allocated buffer sizes and prevents `VIDIOC_QBUF` errors.

Applications must release buffers with `VIDIOC_REQBUFS count=0` before changing the format.

<sup>Written for commit 9e4afcd68cd0c57425c19de2b8d9dca61d459fc4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysprog21/vcam/pull/53?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

