### PR TITLE
media: vcam: set capture buffer sequence numbers

### DIFF
--- a/device.c
+++ b/device.c
@@ -468,6 +468,7 @@ static void submit_noinput_buffer(struct vcam_out_buffer *buf,
             memset(vbuf_ptr, 0xff, rowsize * (rows % 255));
     }
 
+    buf->vb.sequence = dev->sequence++;
     buf->vb.vb2_buf.timestamp = ktime_get_ns();
     vb2_buffer_done(&buf->vb.vb2_buf, VB2_BUF_STATE_DONE);
 }
@@ -648,6 +649,7 @@ static void submit_copy_buffer(struct vcam_out_buffer *out_buf,
             }
         }
     }
+    out_buf->vb.sequence = dev->sequence++;
     out_buf->vb.vb2_buf.timestamp = ktime_get_ns();
     vb2_buffer_done(&out_buf->vb.vb2_buf, VB2_BUF_STATE_DONE);
 }

--- a/device.h
+++ b/device.h
@@ -80,6 +80,7 @@ struct vcam_device {
 
     /* Submitter thread */
     struct task_struct *sub_thr_id;
+    u32 sequence;
 
     /* Format descriptor */
     size_t nr_fmts;

--- a/videobuf.c
+++ b/videobuf.c
@@ -69,6 +69,7 @@ static int vcam_start_streaming(struct vb2_queue *q, unsigned int count)
     struct vcam_device *dev = q->drv_priv;
 
     /* Try to start kernel thread */
+    dev->sequence = 0;
     dev->sub_thr_id = kthread_create(submitter_thread, dev, "vcam_submitter");
     if (!dev->sub_thr_id) {
         pr_err("Failed to create kernel thread\n");


### PR DESCRIPTION
  This patch sets the V4L2 capture buffer sequence number for each completed
  frame.

  Before this change, applications using `VIDIOC_DQBUF` always observed
  `buf.sequence == 0`, even though frames were being streamed successfully. This
  made it impossible for userspace to track frame order through the standard
  V4L2 buffer metadata.

  The fix adds a per-device sequence counter, resets it when streaming starts,
  and assigns it to each completed capture buffer before calling
  `vb2_buffer_done()`.

  Tested with a local MMAP streaming test:

  ```text
  Frame  Index  Sequence  Bytesused  Timestamp(us)
      0      0         0     921600     ...
      1      1         1     921600     ...
      2      2         2     921600     ...
      3      0         3     921600     ...
  Sequence: PASS
  Timestamp: PASS
  Bytesused: PASS
```
  Fixes #54.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set V4L2 capture buffer sequence numbers so `VIDIOC_DQBUF` returns increasing `buf.sequence` and apps can track frame order. Fixes the issue where all frames reported sequence 0.

- **Bug Fixes**
  - Added per-device `sequence` counter to `vcam_device`, reset on stream start.
  - Set `vb.sequence` before `vb2_buffer_done()` in both submit paths.

<sup>Written for commit 6e18f1f15821da521d09cc067a945ffad2fbe1e2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysprog21/vcam/pull/55?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

